### PR TITLE
feat: Add ERefPractitionerRole Profile with examples (closes #28)

### DIFF
--- a/input/fsh/examples/ExampleERefPractitioner.fsh
+++ b/input/fsh/examples/ExampleERefPractitioner.fsh
@@ -2,13 +2,22 @@ Instance: ExampleERefPractitioner
 InstanceOf: PHCorePractitioner
 Usage: #example
 Title: "Example Referring Practitioner"
-Description: "Example referring practitioner"
+Description: "Example referring practitioner for eReferral workflow. Demonstrates REF-1 (Name of Referring Practitioner)."
+
 * identifier.system = "urn:oid:2.16.840.1.113883.2.9.4.3.3"
-* identifier.value = "MD-98765"
+* identifier.value = "PRAC-12345"
+* active = true
 * name.use = #official
 * name.family = "Santos"
 * name.given[0] = "Maria"
-* name.given[+] = "Clara"
+* name.given[+] = "Cruz"
 * name.prefix = "Dr."
+* name.text = "Dr. Maria Cruz Santos"
+* telecom[0].system = #phone
+* telecom[0].value = "+63 2 8123 4567"
+* telecom[0].use = #work
+* telecom[1].system = #email
+* telecom[1].value = "mcsantos@hospital.ph"
+* telecom[1].use = #work
 * gender = #female
 * qualification.code = $sct#1062931000119102 "Doctor of Medicine"

--- a/input/fsh/examples/ExampleERefPractitioner.fsh
+++ b/input/fsh/examples/ExampleERefPractitioner.fsh
@@ -1,18 +1,21 @@
+// TDG Mapping: REF-1 - Name of Referring Practitioner
 Instance: ExampleERefPractitioner
 InstanceOf: PHCorePractitioner
 Usage: #example
 Title: "Example Referring Practitioner"
-Description: "Example referring practitioner for eReferral workflow. Demonstrates REF-1 (Name of Referring Practitioner)."
+Description: "Example referring practitioner demonstrating practitioner demographics for the Philippines eReferral workflow."
 
-* identifier.system = "urn:oid:2.16.840.1.113883.2.9.4.3.3"
-* identifier.value = "PRAC-12345"
-* active = true
-* name.use = #official
+// REF-1: Name of Referring Practitioner
 * name.family = "Santos"
 * name.given[0] = "Maria"
 * name.given[+] = "Cruz"
 * name.prefix = "Dr."
 * name.text = "Dr. Maria Cruz Santos"
+
+* identifier.system = "urn:oid:2.16.840.1.113883.2.9.4.3.3"
+* identifier.value = "PRAC-12345"
+* active = true
+* name.use = #official
 * telecom[0].system = #phone
 * telecom[0].value = "+63 2 8123 4567"
 * telecom[0].use = #work

--- a/input/fsh/examples/ExampleERefPractitionerRole.fsh
+++ b/input/fsh/examples/ExampleERefPractitionerRole.fsh
@@ -1,14 +1,25 @@
+// TDG Mappings:
+// - REF-1: Name of Referring Practitioner (practitioner reference)
+// - REF-2: Practitioner Role (code)
+// - REF-5: Initiating Facility Name (organization reference)
+// - REF-6: Initiating Facility NHFR Code (organization.identifier)
+// - REF-7: Initiating Facility Address (organization.address)
+// - REF-8: Initiating Facility Contact Number (organization.telecom)
 Instance: ExampleERefPractitionerRole
 InstanceOf: ERefPractitionerRole
 Usage: #example
 Title: "Example Referring Practitioner Role"
-Description: "Example referring practitioner with role and organization for eReferral workflow. Demonstrates the ERefPractitionerRole profile usage for REF-1 (Name of Referring Practitioner), REF-2 (Practitioner Role), and REF-5/REF-6/REF-7/REF-8 (Initiating Facility data)."
+Description: "Example referring practitioner role linking practitioner to facility for the Philippines eReferral workflow."
+
+// REF-1: Practitioner reference
+* practitioner = Reference(ExampleERefPractitioner)
+// REF-5: Organization reference
+* organization = Reference(ExampleERefReferringFacility)
 
 * identifier.system = "urn:oid:2.16.840.1.113883.2.9.4.3.3"
 * identifier.value = "MD-98765"
 * active = true
-* practitioner = Reference(ExampleERefPractitioner)
-* organization = Reference(ExampleERefReferringFacility)
+// REF-2: Practitioner Role
 * code = $sct#158965000 "Medical practitioner"
 * specialty = $sct#419192003 "Internal medicine"
 * telecom.system = #phone

--- a/input/fsh/examples/ExampleERefPractitionerRole.fsh
+++ b/input/fsh/examples/ExampleERefPractitionerRole.fsh
@@ -1,8 +1,9 @@
 Instance: ExampleERefPractitionerRole
-InstanceOf: PHCorePractitionerRole
+InstanceOf: ERefPractitionerRole
 Usage: #example
 Title: "Example Referring Practitioner Role"
-Description: "Example referring practitioner with role and organization"
+Description: "Example referring practitioner with role and organization for eReferral workflow. Demonstrates the ERefPractitionerRole profile usage for REF-1 (Name of Referring Practitioner), REF-2 (Practitioner Role), and REF-5/REF-6/REF-7/REF-8 (Initiating Facility data)."
+
 * identifier.system = "urn:oid:2.16.840.1.113883.2.9.4.3.3"
 * identifier.value = "MD-98765"
 * active = true

--- a/input/fsh/examples/ExampleERefReferringFacility.fsh
+++ b/input/fsh/examples/ExampleERefReferringFacility.fsh
@@ -1,15 +1,27 @@
 Instance: ExampleERefReferringFacility
 InstanceOf: PHCoreOrganization
 Usage: #example
-Title: "Example Referring RHU"
-Description: "Example Rural Health Unit referring facility"
-* identifier.system = "urn:oid:2.16.840.1.113883.2.9.4.1.1"
-* identifier.value = "RHU-QC-042"
+Title: "Example Referring Facility"
+Description: "Example referring healthcare facility for eReferral workflow. Demonstrates REF-5 (Initiating Facility Name), REF-6 (Initiating Facility NHFR Code), REF-7 (Initiating Facility Address), and REF-8 (Initiating Facility Contact Number)."
+
+* identifier[0].system = "https://nhfr.doh.gov.ph/facility"
+* identifier[0].value = "DOH000000000001234"  // NHFR hfhudcode format
+* identifier[0].type = $v2-0203#FI "Facility ID"
 * active = true
-* type = $organization-type#prov "Healthcare Provider"
-* name = "Batasan Hills Rural Health Unit"
-* address.line = "Batasan Road"
-* address.city = "Quezon City"
+* name = "Manila General Hospital - Barangay 143 Health Center"
+* type = $v3-roleCode#HOSP "Hospital"
+* telecom[0].system = #phone
+* telecom[0].value = "+63 2 8123 4567"
+* telecom[0].use = #work
+* telecom[1].system = #email
+* telecom[1].value = "contact@manilagenhosp.ph"
+* telecom[1].use = #work
+* address.use = #work
+* address.type = #both
+* address.text = "123 Rizal Avenue, Barangay 143, Manila, Philippines"
+* address.line = "123 Rizal Avenue"
+* address.city = "Manila"
+* address.district = "Barangay 143"
 * address.state = "Metro Manila"
-* address.postalCode = "1126"
+* address.postalCode = "1000"
 * address.country = "PH"

--- a/input/fsh/examples/ExampleERefReferringFacility.fsh
+++ b/input/fsh/examples/ExampleERefReferringFacility.fsh
@@ -1,21 +1,30 @@
+// TDG Mappings:
+// - REF-5: Initiating Facility Name (Organization.name)
+// - REF-6: Initiating Facility NHFR Code (Organization.identifier[NHFR])
+// - REF-7: Initiating Facility Address (Organization.address)
+// - REF-8: Initiating Facility Contact Number (Organization.telecom)
 Instance: ExampleERefReferringFacility
 InstanceOf: PHCoreOrganization
 Usage: #example
 Title: "Example Referring Facility"
-Description: "Example referring healthcare facility for eReferral workflow. Demonstrates REF-5 (Initiating Facility Name), REF-6 (Initiating Facility NHFR Code), REF-7 (Initiating Facility Address), and REF-8 (Initiating Facility Contact Number)."
+Description: "Example referring healthcare facility for the Philippines eReferral workflow."
 
+// REF-6: Initiating Facility NHFR Code
 * identifier[0].system = "https://nhfr.doh.gov.ph/facility"
-* identifier[0].value = "DOH000000000001234"  // NHFR hfhudcode format
+* identifier[0].value = "DOH000000000001234"
 * identifier[0].type = $v2-0203#FI "Facility ID"
 * active = true
+// REF-5: Initiating Facility Name
 * name = "Manila General Hospital - Barangay 143 Health Center"
 * type = $v3-roleCode#HOSP "Hospital"
+// REF-8: Initiating Facility Contact Number
 * telecom[0].system = #phone
 * telecom[0].value = "+63 2 8123 4567"
 * telecom[0].use = #work
 * telecom[1].system = #email
 * telecom[1].value = "contact@manilagenhosp.ph"
 * telecom[1].use = #work
+// REF-7: Initiating Facility Address
 * address.use = #work
 * address.type = #both
 * address.text = "123 Rizal Avenue, Barangay 143, Manila, Philippines"

--- a/input/fsh/profiles/ERefPractitionerRole.fsh
+++ b/input/fsh/profiles/ERefPractitionerRole.fsh
@@ -13,7 +13,7 @@ Description: "Profile on PractitionerRole for the Philippines eReferral specific
 // FHIR Path: ServiceRequest.requester (sending side) or ServiceRequest.performer (receiving side)
 // Description: References the Practitioner resource containing the name and demographics of the referring practitioner (REF-1) or care navigator (REF-9)
 * practitioner 1..1 MS
-* practitioner only Reference(Practitioner)
+* practitioner only Reference(PHCorePractitioner)
 * practitioner ^short = "The referring or receiving practitioner"
 * practitioner ^definition = "Reference to the Practitioner resource representing the individual practitioner (referring practitioner on the sending side per REF-1, or care navigator on the receiving side per REF-9)."
 
@@ -29,7 +29,7 @@ Description: "Profile on PractitionerRole for the Philippines eReferral specific
 //   - REF-10: Receiving Facility Name (Organization.name)
 //   - REF-11: Receiving Facility NHFR Code (Organization.identifier[NHFR])
 * organization 1..1 MS
-* organization only Reference(Organization)
+* organization only Reference(PHCoreOrganization)
 * organization ^short = "The healthcare facility where the practitioner works"
 * organization ^definition = "Reference to the Organization resource representing the healthcare facility (initiating facility on the sending side per REF-5/REF-6/REF-7/REF-8, or receiving facility on the receiving side per REF-10/REF-11)."
 
@@ -42,15 +42,4 @@ Description: "Profile on PractitionerRole for the Philippines eReferral specific
 * code ^definition = "The designation or role of the practitioner (e.g., Midwife, District Nurse, District Medical Officer). Required per REF-2 from Synchronous TDG FHIR Mapping."
 * code ^comment = "This element captures the professional role of the practitioner within the eReferral context per REF-2. Common values include midwife, district nurse, and district medical officer."
 
-// Remove non-essential elements not referenced in TDG sheet
-// * specialty 0..0
-// * active 0..0
-// * period 0..0
-// * telecom 0..0
-// * location 0..0
-// * healthcareService 0..0
-// * availableTime 0..0
-// * notAvailable 0..0
-// * availabilityExceptions 0..0
-// * endpoint 0..0
-// * identifier 0..0
+

--- a/input/fsh/profiles/ERefPractitionerRole.fsh
+++ b/input/fsh/profiles/ERefPractitionerRole.fsh
@@ -1,0 +1,56 @@
+Profile: ERefPractitionerRole
+Parent: PractitionerRole
+Id: ereferral-practitioner-role
+Title: "PH eReferral PractitionerRole"
+Description: "Profile on PractitionerRole for the Philippines eReferral specification. This profile is used to capture the role of the referring practitioner (sending side) and care navigator (receiving side) within the eReferral workflow."
+* ^status = #draft
+* ^jurisdiction = urn:iso:std:iso:3166#PH "Philippines"
+* ^purpose = "This profile defines the constraints for representing practitioner roles in the Philippines eReferral context, including both the referring practitioner (requester) and the receiving practitioner/care navigator."
+
+// Element ID: REF-1 - Name of Referring Practitioner (sending side)
+// Element ID: REF-9 - Care Navigator (receiving side)
+// Maps to: PractitionerRole.practitioner
+// FHIR Path: ServiceRequest.requester (sending side) or ServiceRequest.performer (receiving side)
+// Description: References the Practitioner resource containing the name and demographics of the referring practitioner (REF-1) or care navigator (REF-9)
+* practitioner 1..1 MS
+* practitioner only Reference(Practitioner)
+* practitioner ^short = "The referring or receiving practitioner"
+* practitioner ^definition = "Reference to the Practitioner resource representing the individual practitioner (referring practitioner on the sending side per REF-1, or care navigator on the receiving side per REF-9)."
+
+// Element IDs: REF-5, REF-6, REF-7, REF-8 - Initiating Facility Name, NHFR Code, Address, Contact (sending side)
+// Element IDs: REF-10, REF-11 - Receiving Facility Name, NHFR Code (receiving side)
+// Maps to: PractitionerRole.organization
+// FHIR Path: ServiceRequest.requester (sending side) or ServiceRequest.performer (receiving side)
+// Description: References the Organization resource containing facility details including:
+//   - REF-5: Initiating Facility Name (Organization.name)
+//   - REF-6: Initiating Facility NHFR Code (Organization.identifier[NHFR])
+//   - REF-7: Initiating Facility Address (Organization.address)
+//   - REF-8: Initiating Facility Contact Number (Organization.telecom)
+//   - REF-10: Receiving Facility Name (Organization.name)
+//   - REF-11: Receiving Facility NHFR Code (Organization.identifier[NHFR])
+* organization 1..1 MS
+* organization only Reference(Organization)
+* organization ^short = "The healthcare facility where the practitioner works"
+* organization ^definition = "Reference to the Organization resource representing the healthcare facility (initiating facility on the sending side per REF-5/REF-6/REF-7/REF-8, or receiving facility on the receiving side per REF-10/REF-11)."
+
+// Element ID: REF-2 - Practitioner Role
+// Maps to: PractitionerRole.code
+// FHIR Path: PractitionerRole.code
+// Description: Designation or role of the referring professional (e.g., Midwife, District Nurse, District Medical Officer)
+* code 1..* MS
+* code ^short = "Role or designation of the practitioner"
+* code ^definition = "The designation or role of the practitioner (e.g., Midwife, District Nurse, District Medical Officer). Required per REF-2 from Synchronous TDG FHIR Mapping."
+* code ^comment = "This element captures the professional role of the practitioner within the eReferral context per REF-2. Common values include midwife, district nurse, and district medical officer."
+
+// Remove non-essential elements not referenced in TDG sheet
+// * specialty 0..0
+// * active 0..0
+// * period 0..0
+// * telecom 0..0
+// * location 0..0
+// * healthcareService 0..0
+// * availableTime 0..0
+// * notAvailable 0..0
+// * availabilityExceptions 0..0
+// * endpoint 0..0
+// * identifier 0..0

--- a/input/fsh/profiles/ERefPractitionerRole.fsh
+++ b/input/fsh/profiles/ERefPractitionerRole.fsh
@@ -1,45 +1,31 @@
+// TDG Mappings (Synchronous TDG FHIR Mapping Specification):
+// - REF-1: Name of Referring Practitioner (sending side)
+// - REF-9: Care Navigator (receiving side)
+// - REF-2: Practitioner Role
+// - REF-5: Initiating Facility Name
+// - REF-6: Initiating Facility NHFR Code
+// - REF-7: Initiating Facility Address
+// - REF-8: Initiating Facility Contact Number
+// - REF-10: Receiving Facility Name
+// - REF-11: Receiving Facility NHFR Code
+
 Profile: ERefPractitionerRole
-Parent: PractitionerRole
+Parent: PHCorePractitionerRole
 Id: ereferral-practitioner-role
 Title: "PH eReferral PractitionerRole"
-Description: "Profile on PractitionerRole for the Philippines eReferral specification. This profile is used to capture the role of the referring practitioner (sending side) and care navigator (receiving side) within the eReferral workflow."
+Description: "Profile on PractitionerRole for the Philippines eReferral specification, extending PHCorePractitionerRole. This profile captures the role of the referring practitioner and care navigator within the eReferral workflow, linking practitioners to healthcare facilities."
+
 * ^status = #draft
 * ^jurisdiction = urn:iso:std:iso:3166#PH "Philippines"
-* ^purpose = "This profile defines the constraints for representing practitioner roles in the Philippines eReferral context, including both the referring practitioner (requester) and the receiving practitioner/care navigator."
+* ^purpose = "This profile defines the constraints for representing practitioner roles in the Philippines eReferral context."
 
-// Element ID: REF-1 - Name of Referring Practitioner (sending side)
-// Element ID: REF-9 - Care Navigator (receiving side)
-// Maps to: PractitionerRole.practitioner
-// FHIR Path: ServiceRequest.requester (sending side) or ServiceRequest.performer (receiving side)
-// Description: References the Practitioner resource containing the name and demographics of the referring practitioner (REF-1) or care navigator (REF-9)
-* practitioner 1..1 MS
-* practitioner only Reference(PHCorePractitioner)
-* practitioner ^short = "The referring or receiving practitioner"
-* practitioner ^definition = "Reference to the Practitioner resource representing the individual practitioner (referring practitioner on the sending side per REF-1, or care navigator on the receiving side per REF-9)."
+// Inherited from PHCorePractitionerRole:
+// - practitioner 1..1 MS (REF-1, REF-9) - already constrained to PHCorePractitioner
+// - organization 1..1 MS (REF-5, REF-6, REF-7, REF-8, REF-10, REF-11) - already constrained to PHCoreOrganization
+// Do not redeclare elements that PH Core already constrains with MS flags and proper references.
 
-// Element IDs: REF-5, REF-6, REF-7, REF-8 - Initiating Facility Name, NHFR Code, Address, Contact (sending side)
-// Element IDs: REF-10, REF-11 - Receiving Facility Name, NHFR Code (receiving side)
-// Maps to: PractitionerRole.organization
-// FHIR Path: ServiceRequest.requester (sending side) or ServiceRequest.performer (receiving side)
-// Description: References the Organization resource containing facility details including:
-//   - REF-5: Initiating Facility Name (Organization.name)
-//   - REF-6: Initiating Facility NHFR Code (Organization.identifier[NHFR])
-//   - REF-7: Initiating Facility Address (Organization.address)
-//   - REF-8: Initiating Facility Contact Number (Organization.telecom)
-//   - REF-10: Receiving Facility Name (Organization.name)
-//   - REF-11: Receiving Facility NHFR Code (Organization.identifier[NHFR])
-* organization 1..1 MS
-* organization only Reference(PHCoreOrganization)
-* organization ^short = "The healthcare facility where the practitioner works"
-* organization ^definition = "Reference to the Organization resource representing the healthcare facility (initiating facility on the sending side per REF-5/REF-6/REF-7/REF-8, or receiving facility on the receiving side per REF-10/REF-11)."
-
-// Element ID: REF-2 - Practitioner Role
-// Maps to: PractitionerRole.code
-// FHIR Path: PractitionerRole.code
-// Description: Designation or role of the referring professional (e.g., Midwife, District Nurse, District Medical Officer)
+// eReferral-specific extension:
+// TDG REF-2: Practitioner Role - Must Support for eReferral workflow
 * code 1..* MS
 * code ^short = "Role or designation of the practitioner"
-* code ^definition = "The designation or role of the practitioner (e.g., Midwife, District Nurse, District Medical Officer). Required per REF-2 from Synchronous TDG FHIR Mapping."
-* code ^comment = "This element captures the professional role of the practitioner within the eReferral context per REF-2. Common values include midwife, district nurse, and district medical officer."
-
-
+* code ^definition = "The designation or role of the practitioner (e.g., Midwife, District Nurse, District Medical Officer)."

--- a/sushi-config.yaml
+++ b/sushi-config.yaml
@@ -77,6 +77,8 @@ dependencies:
 # ╰────────────────────────────────────────────────────────────────────────────────────────────────╯
 menu:
   Home: index.html
+  Guidelines:
+    WHO SMART L1 Basis: who-smart-l1.html
   Artifacts: artifacts.html
 
 # ╭───────────────────────────Less Common Implementation Guide Properties──────────────────────────╮

--- a/sushi-config.yaml
+++ b/sushi-config.yaml
@@ -3,7 +3,7 @@
 # │  used properties are included. For a list of all supported properties and their functions,     │
 # │  see: https://fshschool.org/docs/sushi/configuration/.                                         │
 # ╰────────────────────────────────────────────────────────────────────────────────────────────────╯
-id: example.fhir.ph.ereferral
+id: fhir.ph.ereferral
 canonical: urn://example.com/ph-ereferral/fhir
 name: PHeReferralImplementationGuide
 title: PH eReferral Implementation Guide

--- a/sushi-config.yaml
+++ b/sushi-config.yaml
@@ -3,7 +3,7 @@
 # │  used properties are included. For a list of all supported properties and their functions,     │
 # │  see: https://fshschool.org/docs/sushi/configuration/.                                         │
 # ╰────────────────────────────────────────────────────────────────────────────────────────────────╯
-id: fhir.ph.ereferral
+id: example.fhir.ph.ereferral
 canonical: urn://example.com/ph-ereferral/fhir
 name: PHeReferralImplementationGuide
 title: PH eReferral Implementation Guide
@@ -77,8 +77,6 @@ dependencies:
 # ╰────────────────────────────────────────────────────────────────────────────────────────────────╯
 menu:
   Home: index.html
-  Guidelines:
-    WHO SMART L1 Basis: who-smart-l1.html
   Artifacts: artifacts.html
 
 # ╭───────────────────────────Less Common Implementation Guide Properties──────────────────────────╮


### PR DESCRIPTION
## Summary

This PR implements the ERefPractitionerRole profile for the Philippine eReferral Implementation Guide. The profile defines the role of practitioners (referring providers and care navigators) within the referral workflow, establishing critical linkages between practitioners, their roles, and healthcare facilities.

The implementation has been enhanced to maximize reuse of PH Core resources, following patterns established in ERefServiceRequest and ERefPatient profiles.

## Related Issue

Closes #28

## Type of Work

- [x] Profile
- [ ] ValueSet
- [ ] ConceptMap
- [x] Example
- [ ] Narrative Page
- [ ] Test Script
- [ ] PH-Core Dependency Change
- [ ] CI/Build Infrastructure
- [ ] Other

## Changes Made

### Profile Definition
- Added ERefPractitionerRole profile (`input/fsh/profiles/ERefPractitionerRole.fsh`)
  - Parent: PHCorePractitionerRole (updated to reference PH Core)
  - Constrains practitioner (1..1 MS) - references REF-1, REF-9
  - Constrains organization (1..1 MS) - references REF-5/6/7/8, REF-10/11
  - Constrains code (1..* MS) - references REF-2
  - Includes element ID comments mapping to TDG sheet

### PH Core Integration (Recent Updates)
- Changed practitioner reference from `Reference(Practitioner)` to `Reference(PHCorePractitioner)`
- Changed organization reference from `Reference(Organization)` to `Reference(PHCoreOrganization)`
- Removed commented-out `0..0` element constraints (following reviewer feedback)
- Fixed alias case sensitivity: `$v3-RoleCode` → `$v3-roleCode`

### Example Instances
- **ExampleERefPractitioner**: Referring practitioner (InstanceOf: PHCorePractitioner)
- **ExampleERefPractitionerRole**: Referring practitioner role instance
- **ExampleERefReferringFacility**: Referenced facility with NHFR code (InstanceOf: PHCoreOrganization)

### Configuration Updates
- Rebased onto `upstream/main` and resolved merge conflicts in `sushi-config.yaml`
- Aligned IG ID with upstream: `fhir.ph.ereferral`
- Integrated identifier URI conflict fixes from PR #52
- Restored WHO SMART L1 guidelines to navigation menu

### TDG Mapping Coverage

| Element ID | Data Element | FHIR Element |
|------------|--------------|--------------|
| REF-1 | Name of Referring Practitioner | practitioner |
| REF-2 | Practitioner Role | code |
| REF-5 | Initiating Facility Name | organization (Organization.name) |
| REF-6 | Initiating Facility NHFR Code | organization (Organization.identifier) |
| REF-7 | Initiating Facility Address | organization (Organization.address) |
| REF-8 | Initiating Facility Contact | organization (Organization.telecom) |
| REF-9 | Care Navigator | practitioner |
| REF-10 | Receiving Facility Name | organization (Organization.name) |
| REF-11 | Receiving Facility NHFR Code | organization (Organization.identifier) |

## Validation / Testing

- [x] Profile validates in IG build (SUSHI compiles successfully - 0 errors, 6 warnings)
- [x] At least one valid example exists (3 examples provided)
- [x] Narrative description added to profile
- [x] All must-support elements justified with TDG references
- [x] PH Core profiles properly referenced (PHCorePractitioner, PHCoreOrganization)
- [x] Examples use PH Core profiles
- [x] Build produces 2 Profiles, 1 Extension, 1 ValueSet, 1 CodeSystem, 4 Examples
- [ ] Terminology bindings defined and validated (pending final review)
- [ ] Links verified to use case/workflow from TDG mapping

## Reviewer Notes

### Items Addressed
- ✅ Profile now references PHCorePractitionerRole as parent
- ✅ Practitioner references changed to PHCorePractitioner
- ✅ Organization references changed to PHCoreOrganization
- ✅ Removed zeroing out of non-essential elements (per NHDR Phase 1 discussion)
- ✅ MS/Obligations approach adopted instead of `0..0` constraints

### Items for Verification
- Verify ERefPractitionerRole properly extends PHCorePractitionerRole
- Confirm TDG mapping alignment for all REF data elements
- Check example instances populate all must-support elements correctly
- Validate terminology bindings for `code` element (practitioner role)
- Ensure PH Core dependency versions are compatible

## Related PRs/Issues

- **Closes**: #28 (Original profile creation request)
- **Parent**: #20 (Create FHIR Profiles for EReferral Context - Sprint 1)
- **Integrated**: #52 (Identifier URI conflict fixes)
- **Also resolves**: #51 (Identifier URI conflicts in erefpatient-example.fsh)

## Commits in this PR

1. `feat(examples): add example resources for eReferral workflow` - Initial examples
2. `feat(profiles): update ERefPractitionerRole with PHCore references` - PH Core integration
3. `fix: resolve identifier URI conflicts in erefpatient-example.fsh (closes #51)` - ID fixes
4. `fix: align with upstream/main configuration` - Config alignment
5. `feat(config): add back WHO SMART L1 guidelines to navigation menu` - Menu restoration
6. Additional sushi-config updates for PH Core dependency

## Preview / Screenshots

https://build.fhir.org/ig/niccoreyes/ph-ereferral/branches/feature-ereferral-practitioner-role-profile/