### PR TITLE
Add WHO SMART L1 basis page for PH eReferral IG

### DIFF
--- a/input/pagecontent/index.md
+++ b/input/pagecontent/index.md
@@ -1,7 +1,7 @@
 # Philippine eReferral Implementation Guide (PH eReferral IG)
 
 <svg xmlns="http://www.w3.org/2000/svg" role="img" aria-labelledby="title desc" width="100%" viewBox="0 0 1400 200" preserveAspectRatio="xMidYMin meet">
-  <title id="title">DRAFT â€“ PH eReferral IG Disclaimer</title>
+  <title id="title">DRAFT – PH eReferral IG Disclaimer</title>
   <desc id="desc">This guide is a draft and under active development. Not for public consumption.</desc>
 
   <defs>
@@ -60,10 +60,10 @@ For the narrative and policy foundation of this implementation guide, see [WHO S
 
 A use case Implementation Guide builds upon foundational and core standards to address a specific clinical or administrative workflow. Unlike base or core IGs that establish broad interoperability foundations, a use case IG:
 
-- **Targets a specific workflow** â€” in this case, the patient referral process between healthcare facilities
-- **Profiles core resources for the use case** â€” constrains and extends PH Core profiles to meet referral-specific requirements
-- **Defines actors and interactions** â€” identifies systems, users, and the exchanges between them
-- **Specifies business rules** â€” documents the rules governing referral lifecycle, status transitions, and required data elements
+- **Targets a specific workflow** — in this case, the patient referral process between healthcare facilities
+- **Profiles core resources for the use case** — constrains and extends PH Core profiles to meet referral-specific requirements
+- **Defines actors and interactions** — identifies systems, users, and the exchanges between them
+- **Specifies business rules** — documents the rules governing referral lifecycle, status transitions, and required data elements
 
 PH eReferral demonstrates how FHIR resources can be applied to solve a real-world interoperability challenge in the Philippine healthcare system.
 
@@ -94,13 +94,13 @@ PH eReferral fits into the Philippine FHIR IG architecture as a **use case layer
 
 | Layer | IG | Purpose |
 |-------|-----|---------|
-| Core | [PH Core IG](https://github.com/UP-Manila-SILab/ph-core) | **Base profiles** â€“ Foundational rules, common extensions, and national identifiers (Patient, Practitioner, Organization, Encounter, etc.) |
-| **Use Case** | **PH eReferral IG** | **Referral-specific workflows and interactions** â€“ HCPN referral messaging built on PH Core |
+| Core | [PH Core IG](https://github.com/UP-Manila-SILab/ph-core) | **Base profiles** – Foundational rules, common extensions, and national identifiers (Patient, Practitioner, Organization, Encounter, etc.) |
+| **Use Case** | **PH eReferral IG** | **Referral-specific workflows and interactions** – HCPN referral messaging built on PH Core |
 | Program | Program-specific IGs | Tailored implementations for specific health programs or facilities |
 
 PH Core provides the **parent/base profiles** used by this IG. PH eReferral:
 
-- Uses PH Core as its foundation â€“ inheriting constraints from PH Core profiles (Patient, Practitioner, Organization, Encounter, etc.)
+- Uses PH Core as its foundation – inheriting constraints from PH Core profiles (Patient, Practitioner, Organization, Encounter, etc.)
 - Defines referral-specific profiles (ServiceRequest, Task, etc.) for interoperability
 - Specifies the referral workflow actors and their interactions
 - Documents the complete referral lifecycle from creation to fulfillment

--- a/input/pagecontent/index.md
+++ b/input/pagecontent/index.md
@@ -1,7 +1,7 @@
 # Philippine eReferral Implementation Guide (PH eReferral IG)
 
 <svg xmlns="http://www.w3.org/2000/svg" role="img" aria-labelledby="title desc" width="100%" viewBox="0 0 1400 200" preserveAspectRatio="xMidYMin meet">
-  <title id="title">DRAFT – PH eReferral IG Disclaimer</title>
+  <title id="title">DRAFT â€“ PH eReferral IG Disclaimer</title>
   <desc id="desc">This guide is a draft and under active development. Not for public consumption.</desc>
 
   <defs>
@@ -54,16 +54,20 @@ This IG aligns with the **[Universal Health Care Act (Republic Act 11223)](https
 
 This FHIR IG is provided for testing purposes and is not yet suitable for production systems.
 
+For the narrative and policy foundation of this implementation guide, see [WHO SMART Guidelines L1 Basis for the PH eReferral IG](who-smart-l1.html).
+
 ## What is a Use Case IG?
 
 A use case Implementation Guide builds upon foundational and core standards to address a specific clinical or administrative workflow. Unlike base or core IGs that establish broad interoperability foundations, a use case IG:
 
-- **Targets a specific workflow** — in this case, the patient referral process between healthcare facilities
-- **Profiles core resources for the use case** — constrains and extends PH Core profiles to meet referral-specific requirements
-- **Defines actors and interactions** — identifies systems, users, and the exchanges between them
-- **Specifies business rules** — documents the rules governing referral lifecycle, status transitions, and required data elements
+- **Targets a specific workflow** â€” in this case, the patient referral process between healthcare facilities
+- **Profiles core resources for the use case** â€” constrains and extends PH Core profiles to meet referral-specific requirements
+- **Defines actors and interactions** â€” identifies systems, users, and the exchanges between them
+- **Specifies business rules** â€” documents the rules governing referral lifecycle, status transitions, and required data elements
 
 PH eReferral demonstrates how FHIR resources can be applied to solve a real-world interoperability challenge in the Philippine healthcare system.
+
+The corresponding L1 narrative basis page explains how this implementation guide is grounded in national policy, HCPN service-delivery design, primary care coordination, and future traceability to WHO SMART L2 and L3 work.
 
 ## Purpose and Scope
 
@@ -90,13 +94,13 @@ PH eReferral fits into the Philippine FHIR IG architecture as a **use case layer
 
 | Layer | IG | Purpose |
 |-------|-----|---------|
-| Core | [PH Core IG](https://github.com/UP-Manila-SILab/ph-core) | **Base profiles** – Foundational rules, common extensions, and national identifiers (Patient, Practitioner, Organization, Encounter, etc.) |
-| **Use Case** | **PH eReferral IG** | **Referral-specific workflows and interactions** – HCPN referral messaging built on PH Core |
+| Core | [PH Core IG](https://github.com/UP-Manila-SILab/ph-core) | **Base profiles** â€“ Foundational rules, common extensions, and national identifiers (Patient, Practitioner, Organization, Encounter, etc.) |
+| **Use Case** | **PH eReferral IG** | **Referral-specific workflows and interactions** â€“ HCPN referral messaging built on PH Core |
 | Program | Program-specific IGs | Tailored implementations for specific health programs or facilities |
 
 PH Core provides the **parent/base profiles** used by this IG. PH eReferral:
 
-- Uses PH Core as its foundation – inheriting constraints from PH Core profiles (Patient, Practitioner, Organization, Encounter, etc.)
+- Uses PH Core as its foundation â€“ inheriting constraints from PH Core profiles (Patient, Practitioner, Organization, Encounter, etc.)
 - Defines referral-specific profiles (ServiceRequest, Task, etc.) for interoperability
 - Specifies the referral workflow actors and their interactions
 - Documents the complete referral lifecycle from creation to fulfillment

--- a/input/pagecontent/who-smart-l1.md
+++ b/input/pagecontent/who-smart-l1.md
@@ -1,0 +1,145 @@
+# WHO SMART Guidelines L1 Basis for the PH eReferral IG
+
+## Purpose
+
+This page explains the **WHO SMART Guidelines Level 1 (L1)** basis used for the Philippine eReferral Implementation Guide (PH eReferral IG).
+
+In this implementation guide, L1 is the **narrative and policy foundation** for the eReferral use case. It provides the high-level basis for why referral interoperability matters, what policy and service-delivery context applies, and which source references should anchor later design work.
+
+This page is intentionally **foundational rather than exhaustive**. It is not a reproduction of WHO source material or a complete policy compendium. Its role is to provide a concise, traceable starting point for contributors, reviewers, and implementers.
+
+## Why L1 Matters in This IG
+
+WHO SMART Guidelines start from narrative guidance and then move toward increasingly structured and implementation-ready artefacts. For the PH eReferral IG, that means the work should not begin from FHIR profiles alone. It should begin from the policy, workflow, and service-delivery basis that explains:
+
+- why referral and back-referral matter in the Philippine context;
+- how Health Care Provider Networks (HCPNs) frame coordination of care;
+- how primary care acts as the navigator, coordinator, and initial and continuing point of contact within the health system;
+- which national references establish the direction for interoperable referral processes; and
+- how later structured requirements should remain traceable to those narrative sources.
+
+Using an L1 foundation helps keep the PH eReferral IG aligned to real program and system needs instead of treating the IG as a purely technical exercise.
+
+## Intended Use of This Page
+
+This page should be used as a **reference and orientation page** for the PH eReferral IG. It is meant to:
+
+- summarize the narrative basis and guiding references used by this repository;
+- clarify the role and boundaries of L1 in the PH eReferral context;
+- support traceability from narrative guidance to later structured artefacts; and
+- provide a stable entry point for contributors who are new to WHO SMART work.
+
+This page should **summarize and point to authoritative references**, not replace them.
+
+## PH eReferral L1 Basis
+
+The PH eReferral IG is being developed in a context shaped by Philippine universal health care policy and HCPN service-delivery design.
+
+At a minimum, the current L1 basis for this IG includes:
+
+1. **Republic Act No. 11223 (Universal Health Care Act)**, which establishes the national universal health care policy direction and frames integrated and comprehensive health-system delivery.
+2. **DOH Administrative Order No. 2020-0019**, *Guidelines on the Service Delivery Design of Health Care Provider Networks*, which describes the HCPN context in which referral coordination and service delivery operate.
+3. **DOH Administrative Order No. 2020-0024**, *Primary Care Policy Framework and Sectoral Strategies*, which clarifies the primary care role as navigator, coordinator, and continuing point of contact, and emphasizes continuity and coordination of care.
+4. **DOH Administrative Order No. 2020-0021**, *Guidelines on Integration of the Local Health Systems into Province-wide and City-wide Health Systems (P/CWHS)*, which situates HCPNs and PCPNs within integrated local health-system delivery and explicitly includes two-way referrals, patient navigation, records access, and digital technologies for health.
+
+Together, these sources provide the narrative basis for treating eReferral as part of coordinated, standards-aligned, network-based care delivery rather than as a standalone messaging feature.
+
+## Key Narrative Basis from the Referenced Sources
+
+The current source set indicates the following narrative basis for PH eReferral:
+
+- **RA 11223 / UHC policy direction**: health-system design should support integrated, comprehensive, and coordinated care rather than fragmented service delivery.
+- **AO 2020-0019 / HCPN design**: HCPNs are expected to deliver continuous health care from primary to tertiary levels through safe, efficient, and coordinated mechanisms.
+- **AO 2020-0019 / referrals**: the order explicitly calls for a functional referral system, localized referral protocols, patient navigation and coordination, standardized communication processes, a uniform referral form, and a back-referral form with follow-up and home instructions.
+- **AO 2020-0019 / interoperability**: HCPNs are expected to have a patient record management system with interoperable electronic medical records capable of real-time information sharing across member facilities.
+- **AO 2020-0024 / primary care policy**: primary care is positioned as the navigator, coordinator, and initial and continuing point of contact, with continuity of care across health conditions and levels of care.
+- **AO 2020-0021 / integrated local systems**: PCPNs are described as the foundation of HCPNs and are responsible for serving as initial contact and navigator, coordinating patients to facilitate two-way referrals, and supporting access across levels of care, including the use of digital technologies for health.
+
+These points are the main reason this implementation guide needs a dedicated L1 basis page. They establish that referral interoperability in this project is rooted in coordinated service delivery, networked care, patient navigation, and continuity of care, not only in technical message exchange.
+
+## What This Means for the PH eReferral IG
+
+For this implementation guide, the L1 basis should be understood as establishing the following project direction:
+
+- the PH eReferral IG supports referral and back-referral as part of coordinated care across HCPNs;
+- the IG should treat primary care and PCPN functions as central to referral coordination and continuity of care;
+- the IG should reflect the service-delivery and interoperability needs implied by national policy and HCPN design guidance;
+- the IG should support standardized referral communication, patient navigation, and records exchange across participating facilities;
+- the narrative basis should remain visible and traceable as the project moves into more structured requirements and technical implementation artefacts; and
+- policy and workflow intent should be distinguished from FHIR-specific design decisions.
+
+## Boundaries of This Page
+
+This page does **not**:
+
+- reproduce the full text of WHO SMART materials;
+- restate the full text of Philippine laws, administrative orders, or manuals;
+- define all L2 Digital Adaptation Kit (DAK) content;
+- define full workflow logic, data elements, decision-support logic, or indicators; or
+- act as the final source of technical conformance requirements.
+
+Instead, this page provides the narrative basis that later work can refine into structured requirements and implementation artefacts.
+
+## Relationship to WHO SMART L2 and L3 Work
+
+The PH eReferral IG should treat this L1 page as the narrative foundation for downstream work.
+
+| SMART level | Role in this project | Expected output in PH eReferral work |
+|---|---|---|
+| **L1 Narrative guidance** | Describes the policy, service-delivery, and guideline basis for the use case | This page and linked source references |
+| **L2 DAK / structured requirements** | Converts narrative guidance into operational and structured requirements | Business processes, actors, data needs, rules, and other structured artefacts |
+| **L3 FHIR IG / technical implementation** | Expresses computable and testable implementation content | FHIR profiles, examples, terminology bindings, interactions, and validation-ready guidance |
+
+This separation matters. The PH eReferral IG should not collapse L1, L2, and L3 into one page or one type of artefact. Each layer serves a different purpose and should remain traceable to the layer above it.
+
+## Traceability Expectations
+
+To support future alignment with L2 DAK and L3 IG work, narrative statements on this page should be traceable to authoritative references.
+
+Where later project artefacts introduce a workflow rule, actor responsibility, business requirement, or technical constraint, those artefacts should identify whether the basis comes from:
+
+- a WHO SMART narrative reference;
+- a Philippine policy or administrative source;
+- a project-level interpretation needed for the PH eReferral use case; or
+- a later design decision introduced during L2 or L3 work.
+
+## PH-Specific Interpretation Notes
+
+The following interpretation points apply to this page:
+
+- This page is a **project-oriented summary** of the L1 basis for the PH eReferral IG.
+- Philippine policy and HCPN references are used here as the immediate narrative basis for the local implementation context.
+- If the repository later adopts additional WHO SMART source references, those should be added explicitly rather than assumed.
+- Any PH-specific interpretation or adaptation beyond the cited source materials should be labeled clearly in future revisions.
+
+## Authoritative References
+
+### WHO SMART references
+
+- [WHO SMART Guidelines overview](https://www.who.int/teams/digital-health-and-innovation/smart-guidelines/)
+- [WHO SMART Guidelines: Digital Adaptation Kits overview](https://www.who.int/publications/m/item/who-digital-accelerator-kits)
+
+### Philippine references currently used by this project
+
+- [Republic Act No. 11223, Universal Health Care Act](https://elibrary.judiciary.gov.ph/thebookshelf/showdocs/2/86448)
+- [DOH Administrative Order No. 2020-0019, Guidelines on the Service Delivery Design of Health Care Provider Networks](https://drive.google.com/file/d/1Uri9Iov3YPw3rc3AidV6dXjv8y_W7ydr/view)
+- [DOH Administrative Order No. 2020-0019-A, Amendment to Administrative Order No. 2020-0019 dated May 14, 2020 Entitled "Guidelines on the Service Delivery Design of Health Care Provider Networks"](https://drive.google.com/file/d/1bkQLF3YU15UZuRHJKlMGBgcJLIMl9ESp/view)
+- [DOH Administrative Order No. 2020-0024, Primary Care Policy Framework and Sectoral Strategies](https://law.upd.edu.ph/wp-content/uploads/2020/06/DOH-AO-No-2020-0024.pdf)
+- [DOH Administrative Order No. 2020-0021, Guidelines on Integration of the Local Health Systems into Province-wide and City-wide Health Systems (P/CWHS)](https://law.upd.edu.ph/wp-content/uploads/2020/05/DOH-AO-No_2020-0021.pdf)
+- [Public Health Unit Manual of Operations](https://drive.usercontent.google.com/download?id=18TW6zePVfbH6Ich2XuyS6Jqq3rPWChjG&authuser=0&acrobatPromotionSource=gdrive_chrome-list)
+
+### Additional project references to confirm
+
+- `[Placeholder]` Additional WHO SMART source reference(s) adopted by the project
+- `[Placeholder]` Additional DOH / operational guidance reference(s) used to refine the PH eReferral narrative basis
+- `[Placeholder]` Repository location for linked L2 DAK artefacts
+- `[Placeholder]` Repository location for linked L3 FHIR IG artefacts
+
+## Maintenance Notes
+
+This page should be updated when:
+
+- the project confirms additional WHO SMART references as normative inputs;
+- the repository establishes linked L2 artefacts that should be referenced here;
+- the repository establishes linked L3 artefacts that should be referenced here; or
+- the project agrees on PH-specific interpretation notes that should be documented for traceability.

--- a/input/pagecontent/who-smart-l1.md
+++ b/input/pagecontent/who-smart-l1.md
@@ -94,7 +94,6 @@ The PH eReferral IG should treat this L1 page as the narrative foundation for do
   </thead>
   <tbody>
     <tr>
-    <tr>
       <td style="text-align: left; padding: 6px 10px; border: 1px solid #ccc; font-weight: bold;">L1 Narrative guidance</td>
       <td style="text-align: left; padding: 6px 10px; border: 1px solid #ccc;">Describes the policy, service-delivery, and guideline basis for the use case</td>
       <td style="text-align: left; padding: 6px 10px; border: 1px solid #ccc;">This page and linked source references</td>

--- a/input/pagecontent/who-smart-l1.md
+++ b/input/pagecontent/who-smart-l1.md
@@ -87,26 +87,27 @@ The PH eReferral IG should treat this L1 page as the narrative foundation for do
 <table style="width: 100%; border-collapse: collapse; border: 1px solid #ccc; margin: 1em 0;">
   <thead>
     <tr style="background-color: #f5f5f5;">
-      <th style="text-align: left; padding: 12px 15px; border: 1px solid #ccc; font-weight: bold;">SMART level</th>
-      <th style="text-align: left; padding: 12px 15px; border: 1px solid #ccc; font-weight: bold;">Role in this project</th>
-      <th style="text-align: left; padding: 12px 15px; border: 1px solid #ccc; font-weight: bold;">Expected output in PH eReferral work</th>
+      <th style="text-align: left; padding: 6px 10px; border: 1px solid #ccc; font-weight: bold;">SMART level</th>
+      <th style="text-align: left; padding: 6px 10px; border: 1px solid #ccc; font-weight: bold;">Role in this project</th>
+      <th style="text-align: left; padding: 6px 10px; border: 1px solid #ccc; font-weight: bold;">Expected output in PH eReferral work</th>
     </tr>
   </thead>
   <tbody>
     <tr>
-      <td style="text-align: left; padding: 12px 15px; border: 1px solid #ccc; font-weight: bold;">L1 Narrative guidance</td>
-      <td style="text-align: left; padding: 12px 15px; border: 1px solid #ccc;">Describes the policy, service-delivery, and guideline basis for the use case</td>
-      <td style="text-align: left; padding: 12px 15px; border: 1px solid #ccc;">This page and linked source references</td>
+    <tr>
+      <td style="text-align: left; padding: 6px 10px; border: 1px solid #ccc; font-weight: bold;">L1 Narrative guidance</td>
+      <td style="text-align: left; padding: 6px 10px; border: 1px solid #ccc;">Describes the policy, service-delivery, and guideline basis for the use case</td>
+      <td style="text-align: left; padding: 6px 10px; border: 1px solid #ccc;">This page and linked source references</td>
     </tr>
     <tr style="background-color: #fafafa;">
-      <td style="text-align: left; padding: 12px 15px; border: 1px solid #ccc; font-weight: bold;">L2 DAK / structured requirements</td>
-      <td style="text-align: left; padding: 12px 15px; border: 1px solid #ccc;">Converts narrative guidance into operational and structured requirements</td>
-      <td style="text-align: left; padding: 12px 15px; border: 1px solid #ccc;">Business processes, actors, data needs, rules, and other structured artefacts</td>
+      <td style="text-align: left; padding: 6px 10px; border: 1px solid #ccc; font-weight: bold;">L2 DAK / structured requirements</td>
+      <td style="text-align: left; padding: 6px 10px; border: 1px solid #ccc;">Converts narrative guidance into operational and structured requirements</td>
+      <td style="text-align: left; padding: 6px 10px; border: 1px solid #ccc;">Business processes, actors, data needs, rules, and other structured artefacts</td>
     </tr>
     <tr>
-      <td style="text-align: left; padding: 12px 15px; border: 1px solid #ccc; font-weight: bold;">L3 FHIR IG / technical implementation</td>
-      <td style="text-align: left; padding: 12px 15px; border: 1px solid #ccc;">Expresses computable and testable implementation content</td>
-      <td style="text-align: left; padding: 12px 15px; border: 1px solid #ccc;">FHIR profiles, examples, terminology bindings, interactions, and validation-ready guidance</td>
+      <td style="text-align: left; padding: 6px 10px; border: 1px solid #ccc; font-weight: bold;">L3 FHIR IG / technical implementation</td>
+      <td style="text-align: left; padding: 6px 10px; border: 1px solid #ccc;">Expresses computable and testable implementation content</td>
+      <td style="text-align: left; padding: 6px 10px; border: 1px solid #ccc;">FHIR profiles, examples, terminology bindings, interactions, and validation-ready guidance</td>
     </tr>
   </tbody>
 </table>

--- a/input/pagecontent/who-smart-l1.md
+++ b/input/pagecontent/who-smart-l1.md
@@ -37,10 +37,10 @@ The PH eReferral IG is being developed in a context shaped by Philippine univers
 
 At a minimum, the current L1 basis for this IG includes:
 
-1. **Republic Act No. 11223 (Universal Health Care Act)**, which establishes the national universal health care policy direction and frames integrated and comprehensive health-system delivery.
-2. **DOH Administrative Order No. 2020-0019**, *Guidelines on the Service Delivery Design of Health Care Provider Networks*, which describes the HCPN context in which referral coordination and service delivery operate.
-3. **DOH Administrative Order No. 2020-0024**, *Primary Care Policy Framework and Sectoral Strategies*, which clarifies the primary care role as navigator, coordinator, and continuing point of contact, and emphasizes continuity and coordination of care.
-4. **DOH Administrative Order No. 2020-0021**, *Guidelines on Integration of the Local Health Systems into Province-wide and City-wide Health Systems (P/CWHS)*, which situates HCPNs and PCPNs within integrated local health-system delivery and explicitly includes two-way referrals, patient navigation, records access, and digital technologies for health.
+1. [**Republic Act No. 11223** (Universal Health Care Act)](https://elibrary.judiciary.gov.ph/thebookshelf/showdocs/2/86448), which establishes the national universal health care policy direction and frames integrated and comprehensive health-system delivery.
+2. [**DOH Administrative Order No. 2020-0019**](https://drive.google.com/file/d/1Uri9Iov3YPw3rc3AidV6dXjv8y_W7ydr/view), *Guidelines on the Service Delivery Design of Health Care Provider Networks*, which describes the HCPN context in which referral coordination and service delivery operate.
+3. [**DOH Administrative Order No. 2020-0024**](https://law.upd.edu.ph/wp-content/uploads/2020/06/DOH-AO-No-2020-0024.pdf), *Primary Care Policy Framework and Sectoral Strategies*, which clarifies the primary care role as navigator, coordinator, and continuing point of contact, and emphasizes continuity and coordination of care.
+4. [**DOH Administrative Order No. 2020-0021**](https://law.upd.edu.ph/wp-content/uploads/2020/05/DOH-AO-No_2020-0021.pdf), *Guidelines on Integration of the Local Health Systems into Province-wide and City-wide Health Systems (P/CWHS)*, which situates HCPNs and PCPNs within integrated local health-system delivery and explicitly includes two-way referrals, patient navigation, records access, and digital technologies for health.
 
 Together, these sources provide the narrative basis for treating eReferral as part of coordinated, standards-aligned, network-based care delivery rather than as a standalone messaging feature.
 
@@ -48,12 +48,12 @@ Together, these sources provide the narrative basis for treating eReferral as pa
 
 The current source set indicates the following narrative basis for PH eReferral:
 
-- **RA 11223 / UHC policy direction**: health-system design should support integrated, comprehensive, and coordinated care rather than fragmented service delivery.
-- **AO 2020-0019 / HCPN design**: HCPNs are expected to deliver continuous health care from primary to tertiary levels through safe, efficient, and coordinated mechanisms.
-- **AO 2020-0019 / referrals**: the order explicitly calls for a functional referral system, localized referral protocols, patient navigation and coordination, standardized communication processes, a uniform referral form, and a back-referral form with follow-up and home instructions.
-- **AO 2020-0019 / interoperability**: HCPNs are expected to have a patient record management system with interoperable electronic medical records capable of real-time information sharing across member facilities.
-- **AO 2020-0024 / primary care policy**: primary care is positioned as the navigator, coordinator, and initial and continuing point of contact, with continuity of care across health conditions and levels of care.
-- **AO 2020-0021 / integrated local systems**: PCPNs are described as the foundation of HCPNs and are responsible for serving as initial contact and navigator, coordinating patients to facilitate two-way referrals, and supporting access across levels of care, including the use of digital technologies for health.
+- [**RA 11223 / UHC policy direction**](https://elibrary.judiciary.gov.ph/thebookshelf/showdocs/2/86448): health-system design should support integrated, comprehensive, and coordinated care rather than fragmented service delivery.
+- [**AO 2020-0019 / HCPN design**](https://drive.google.com/file/d/1Uri9Iov3YPw3rc3AidV6dXjv8y_W7ydr/view): HCPNs are expected to deliver continuous health care from primary to tertiary levels through safe, efficient, and coordinated mechanisms.
+- [**AO 2020-0019 / referrals**](https://drive.google.com/file/d/1Uri9Iov3YPw3rc3AidV6dXjv8y_W7ydr/view): the order explicitly calls for a functional referral system, localized referral protocols, patient navigation and coordination, standardized communication processes, a uniform referral form, and a back-referral form with follow-up and home instructions.
+- [**AO 2020-0019 / interoperability**](https://drive.google.com/file/d/1Uri9Iov3YPw3rc3AidV6dXjv8y_W7ydr/view): HCPNs are expected to have a patient record management system with interoperable electronic medical records capable of real-time information sharing across member facilities.
+- [**AO 2020-0024 / primary care policy**](https://law.upd.edu.ph/wp-content/uploads/2020/06/DOH-AO-No-2020-0024.pdf): primary care is positioned as the navigator, coordinator, and initial and continuing point of contact, with continuity of care across health conditions and levels of care.
+- [**AO 2020-0021 / integrated local systems**](https://law.upd.edu.ph/wp-content/uploads/2020/05/DOH-AO-No_2020-0021.pdf): PCPNs are described as the foundation of HCPNs and are responsible for serving as initial contact and navigator, coordinating patients to facilitate two-way referrals, and supporting access across levels of care, including the use of digital technologies for health.
 
 These points are the main reason this implementation guide needs a dedicated L1 basis page. They establish that referral interoperability in this project is rooted in coordinated service delivery, networked care, patient navigation, and continuity of care, not only in technical message exchange.
 
@@ -84,11 +84,32 @@ Instead, this page provides the narrative basis that later work can refine into 
 
 The PH eReferral IG should treat this L1 page as the narrative foundation for downstream work.
 
-| SMART level | Role in this project | Expected output in PH eReferral work |
-|---|---|---|
-| **L1 Narrative guidance** | Describes the policy, service-delivery, and guideline basis for the use case | This page and linked source references |
-| **L2 DAK / structured requirements** | Converts narrative guidance into operational and structured requirements | Business processes, actors, data needs, rules, and other structured artefacts |
-| **L3 FHIR IG / technical implementation** | Expresses computable and testable implementation content | FHIR profiles, examples, terminology bindings, interactions, and validation-ready guidance |
+<table style="width: 100%; border-collapse: collapse; border: 1px solid #ccc; margin: 1em 0;">
+  <thead>
+    <tr style="background-color: #f5f5f5;">
+      <th style="text-align: left; padding: 12px 15px; border: 1px solid #ccc; font-weight: bold;">SMART level</th>
+      <th style="text-align: left; padding: 12px 15px; border: 1px solid #ccc; font-weight: bold;">Role in this project</th>
+      <th style="text-align: left; padding: 12px 15px; border: 1px solid #ccc; font-weight: bold;">Expected output in PH eReferral work</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td style="text-align: left; padding: 12px 15px; border: 1px solid #ccc; font-weight: bold;">L1 Narrative guidance</td>
+      <td style="text-align: left; padding: 12px 15px; border: 1px solid #ccc;">Describes the policy, service-delivery, and guideline basis for the use case</td>
+      <td style="text-align: left; padding: 12px 15px; border: 1px solid #ccc;">This page and linked source references</td>
+    </tr>
+    <tr style="background-color: #fafafa;">
+      <td style="text-align: left; padding: 12px 15px; border: 1px solid #ccc; font-weight: bold;">L2 DAK / structured requirements</td>
+      <td style="text-align: left; padding: 12px 15px; border: 1px solid #ccc;">Converts narrative guidance into operational and structured requirements</td>
+      <td style="text-align: left; padding: 12px 15px; border: 1px solid #ccc;">Business processes, actors, data needs, rules, and other structured artefacts</td>
+    </tr>
+    <tr>
+      <td style="text-align: left; padding: 12px 15px; border: 1px solid #ccc; font-weight: bold;">L3 FHIR IG / technical implementation</td>
+      <td style="text-align: left; padding: 12px 15px; border: 1px solid #ccc;">Expresses computable and testable implementation content</td>
+      <td style="text-align: left; padding: 12px 15px; border: 1px solid #ccc;">FHIR profiles, examples, terminology bindings, interactions, and validation-ready guidance</td>
+    </tr>
+  </tbody>
+</table>
 
 This separation matters. The PH eReferral IG should not collapse L1, L2, and L3 into one page or one type of artefact. Each layer serves a different purpose and should remain traceable to the layer above it.
 

--- a/sushi-config.yaml
+++ b/sushi-config.yaml
@@ -1,13 +1,13 @@
-# ╭─────────────────────────Commonly Used ImplementationGuide Properties───────────────────────────╮
-# │  The properties below are used to create the ImplementationGuide resource. The most commonly   │
-# │  used properties are included. For a list of all supported properties and their functions,     │
-# │  see: https://fshschool.org/docs/sushi/configuration/.                                         │
-# ╰────────────────────────────────────────────────────────────────────────────────────────────────╯
+# â•­â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€Commonly Used ImplementationGuide Propertiesâ”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â•®
+# â”‚  The properties below are used to create the ImplementationGuide resource. The most commonly   â”‚
+# â”‚  used properties are included. For a list of all supported properties and their functions,     â”‚
+# â”‚  see: https://fshschool.org/docs/sushi/configuration/.                                         â”‚
+# â•°â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â•­â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â•¯
 id: example.fhir.ph.ereferral
 canonical: urn://example.com/ph-ereferral/fhir
 name: PHeReferralImplementationGuide
 title: PH eReferral Implementation Guide
-description: This implementation guide is provided to support the use of FHIR®© in an Philippines context, and defines the minimum set of constraints on the FHIR resources to create the PH eReferral profiles. This implementation guide forms the foundation to build future PH Realm FHIR implementation guides and its content will continue to grow to meet the needs of PH implementers.
+description: This implementation guide is provided to support the use of FHIRÂ®Â© in an Philippines context, and defines the minimum set of constraints on the FHIR resources to create the PH eReferral profiles. This implementation guide forms the foundation to build future PH Realm FHIR implementation guides and its content will continue to grow to meet the needs of PH implementers.
 status: draft # draft | active | retired | unknown
 version: 0.1.0
 fhirVersion: 4.0.1 # https://www.hl7.org/fhir/valueset-FHIR-version.html
@@ -66,22 +66,23 @@ publisher:
 #   excludettl: true
 #   validation: [allow-any-extensions, no-broken-links]
 #
-# ╭────────────────────────────────────────────menu.xml────────────────────────────────────────────╮
-# │ The menu property will be used to generate the input/menu.xml file. The menu is represented    │
-# │ as a simple structure where the YAML key is the menu item name and the value is the URL.       │
-# │ The IG publisher currently only supports one level deep on sub-menus. To provide a             │
-# │ custom menu.xml file, do not include this property and include a `menu.xml` file in            │
-# │ input/includes. To use a provided input/includes/menu.xml file, delete the "menu"              │
-# │ property below.                                                                                │
-# ╰────────────────────────────────────────────────────────────────────────────────────────────────╯
-menu:
+# â•­â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€menu.xmlâ”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â•®
+# â”‚ The menu property will be used to generate the input/menu.xml file. The menu is represented    â”‚
+# â”‚ as a simple structure where the YAML key is the menu item name and the value is the URL.       â”‚
+# â”‚ The IG publisher currently only supports one level deep on sub-menus. To provide a             â”‚
+# â”‚ custom menu.xml file, do not include this property and include a `menu.xml` file in            â”‚
+# â”‚ input/includes. To use a provided input/includes/menu.xml file, delete the "menu"              â”‚
+# â”‚ property below.                                                                                â”‚
+# â•°â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€menu:
   Home: index.html
+  Guidance:
+    WHO SMART L1 Basis: who-smart-l1.html
   Artifacts: artifacts.html
 
-# ╭───────────────────────────Less Common Implementation Guide Properties──────────────────────────╮
-# │  Uncomment the properties below to configure additional properties on the ImplementationGuide  │
-# │  resource. These properties are less commonly needed than those above.                         │
-# ╰────────────────────────────────────────────────────────────────────────────────────────────────╯
+# â•­â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€Less Common Implementation Guide Propertiesâ”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â•®
+# â”‚  Uncomment the properties below to configure additional properties on the ImplementationGuide  â”‚
+# â”‚  resource. These properties are less commonly needed than those above.                         â”‚
+# â•°â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â•¯
 #
 # Those who need more control or want to add additional details to the contact values can use
 # contact directly and follow the format outlined in the ImplementationGuide resource and
@@ -178,9 +179,9 @@ menu:
 
 language: en
 #
-# ╭──────────────────────────────────────────SUSHI flags───────────────────────────────────────────╮
-# │  The flags below configure aspects of how SUSHI processes FSH.                                 │
-# ╰────────────────────────────────────────────────────────────────────────────────────────────────╯
+# â•­â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€SUSHI flagsâ”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â•®
+# â”‚  The flags below configure aspects of how SUSHI processes FSH.                                 â”‚
+# â•°â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â•¯
 # The FSHOnly flag indicates if only FSH resources should be exported.
 # If set to true, no IG related content will be generated.
 # The default value for this property is false.

--- a/sushi-config.yaml
+++ b/sushi-config.yaml
@@ -1,13 +1,13 @@
-# â•­â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€Commonly Used ImplementationGuide Propertiesâ”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â•®
-# â”‚  The properties below are used to create the ImplementationGuide resource. The most commonly   â”‚
-# â”‚  used properties are included. For a list of all supported properties and their functions,     â”‚
-# â”‚  see: https://fshschool.org/docs/sushi/configuration/.                                         â”‚
-# â•°â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â•­â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â•¯
+# ╭─────────────────────────Commonly Used ImplementationGuide Properties──────────────────────────────╮
+# │  The properties below are used to create the ImplementationGuide resource. The most commonly   │
+# │  used properties are included. For a list of all supported properties and their functions,     │
+# │  see: https://fshschool.org/docs/sushi/configuration/.                                         │
+# ╰────────────────────────────────────────────────────────╭───────────────────╯
 id: example.fhir.ph.ereferral
 canonical: urn://example.com/ph-ereferral/fhir
 name: PHeReferralImplementationGuide
 title: PH eReferral Implementation Guide
-description: This implementation guide is provided to support the use of FHIRÂ®Â© in an Philippines context, and defines the minimum set of constraints on the FHIR resources to create the PH eReferral profiles. This implementation guide forms the foundation to build future PH Realm FHIR implementation guides and its content will continue to grow to meet the needs of PH implementers.
+description: This implementation guide is provided to support the use of FHIR®© in an Philippines context, and defines the minimum set of constraints on the FHIR resources to create the PH eReferral profiles. This implementation guide forms the foundation to build future PH Realm FHIR implementation guides and its content will continue to grow to meet the needs of PH implementers.
 status: draft # draft | active | retired | unknown
 version: 0.1.0
 fhirVersion: 4.0.1 # https://www.hl7.org/fhir/valueset-FHIR-version.html
@@ -66,23 +66,23 @@ publisher:
 #   excludettl: true
 #   validation: [allow-any-extensions, no-broken-links]
 #
-# â•­â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€menu.xmlâ”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â•®
-# â”‚ The menu property will be used to generate the input/menu.xml file. The menu is represented    â”‚
-# â”‚ as a simple structure where the YAML key is the menu item name and the value is the URL.       â”‚
-# â”‚ The IG publisher currently only supports one level deep on sub-menus. To provide a             â”‚
-# â”‚ custom menu.xml file, do not include this property and include a `menu.xml` file in            â”‚
-# â”‚ input/includes. To use a provided input/includes/menu.xml file, delete the "menu"              â”‚
-# â”‚ property below.                                                                                â”‚
-# â•°â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€menu:
+# ╭────────────────────────────────────menu.xml────────────────────────────────────────────╮
+# │ The menu property will be used to generate the input/menu.xml file. The menu is represented    │
+# │ as a simple structure where the YAML key is the menu item name and the value is the URL.       │
+# │ The IG publisher currently only supports one level deep on sub-menus. To provide a             │
+# │ custom menu.xml file, do not include this property and include a `menu.xml` file in            │
+# │ input/includes. To use a provided input/includes/menu.xml file, delete the "menu"              │
+# │ property below.                                                                                │
+# ╰───────────────────────────────────────────────────────────────menu:
   Home: index.html
   Guidance:
     WHO SMART L1 Basis: who-smart-l1.html
   Artifacts: artifacts.html
 
-# â•­â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€Less Common Implementation Guide Propertiesâ”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â•®
-# â”‚  Uncomment the properties below to configure additional properties on the ImplementationGuide  â”‚
-# â”‚  resource. These properties are less commonly needed than those above.                         â”‚
-# â•°â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â•¯
+# ╭──────────────────────────Less Common Implementation Guide Properties───────────────────────╮
+# │  Uncomment the properties below to configure additional properties on the ImplementationGuide  │
+# │  resource. These properties are less commonly needed than those above.                         │
+# ╰───────────────────────────────────────────────────────────────╯
 #
 # Those who need more control or want to add additional details to the contact values can use
 # contact directly and follow the format outlined in the ImplementationGuide resource and
@@ -179,9 +179,9 @@ publisher:
 
 language: en
 #
-# â•­â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€SUSHI flagsâ”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â•®
-# â”‚  The flags below configure aspects of how SUSHI processes FSH.                                 â”‚
-# â•°â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â•¯
+# ╭───────────────────────────SUSHI flags──────────────────────────────────╮
+# │  The flags below configure aspects of how SUSHI processes FSH.                                 │
+# ╰────────────────────────────────────────────────────────────────────╯
 # The FSHOnly flag indicates if only FSH resources should be exported.
 # If set to true, no IG related content will be generated.
 # The default value for this property is false.

--- a/sushi-config.yaml
+++ b/sushi-config.yaml
@@ -1,8 +1,8 @@
-# ╭─────────────────────────Commonly Used ImplementationGuide Properties──────────────────────────────╮
+# ╭─────────────────────────Commonly Used ImplementationGuide Properties───────────────────────────╮
 # │  The properties below are used to create the ImplementationGuide resource. The most commonly   │
 # │  used properties are included. For a list of all supported properties and their functions,     │
 # │  see: https://fshschool.org/docs/sushi/configuration/.                                         │
-# ╰────────────────────────────────────────────────────────╭───────────────────╯
+# ╰────────────────────────────────────────────────────────────────────────────────────────────────╯
 id: example.fhir.ph.ereferral
 canonical: urn://example.com/ph-ereferral/fhir
 name: PHeReferralImplementationGuide
@@ -66,23 +66,24 @@ publisher:
 #   excludettl: true
 #   validation: [allow-any-extensions, no-broken-links]
 #
-# ╭────────────────────────────────────menu.xml────────────────────────────────────────────╮
+# ╭────────────────────────────────────────────menu.xml────────────────────────────────────────────╮
 # │ The menu property will be used to generate the input/menu.xml file. The menu is represented    │
 # │ as a simple structure where the YAML key is the menu item name and the value is the URL.       │
 # │ The IG publisher currently only supports one level deep on sub-menus. To provide a             │
 # │ custom menu.xml file, do not include this property and include a `menu.xml` file in            │
 # │ input/includes. To use a provided input/includes/menu.xml file, delete the "menu"              │
 # │ property below.                                                                                │
-# ╰───────────────────────────────────────────────────────────────menu:
+# ╰────────────────────────────────────────────────────────────────────────────────────────────────╯
+menu:
   Home: index.html
   Guidance:
     WHO SMART L1 Basis: who-smart-l1.html
   Artifacts: artifacts.html
 
-# ╭──────────────────────────Less Common Implementation Guide Properties───────────────────────╮
+# ╭───────────────────────────Less Common Implementation Guide Properties──────────────────────────╮
 # │  Uncomment the properties below to configure additional properties on the ImplementationGuide  │
 # │  resource. These properties are less commonly needed than those above.                         │
-# ╰───────────────────────────────────────────────────────────────╯
+# ╰────────────────────────────────────────────────────────────────────────────────────────────────╯
 #
 # Those who need more control or want to add additional details to the contact values can use
 # contact directly and follow the format outlined in the ImplementationGuide resource and
@@ -179,9 +180,9 @@ publisher:
 
 language: en
 #
-# ╭───────────────────────────SUSHI flags──────────────────────────────────╮
+# ╭──────────────────────────────────────────SUSHI flags───────────────────────────────────────────╮
 # │  The flags below configure aspects of how SUSHI processes FSH.                                 │
-# ╰────────────────────────────────────────────────────────────────────╯
+# ╰────────────────────────────────────────────────────────────────────────────────────────────────╯
 # The FSHOnly flag indicates if only FSH resources should be exported.
 # If set to true, no IG related content will be generated.
 # The default value for this property is false.

--- a/sushi-config.yaml
+++ b/sushi-config.yaml
@@ -76,7 +76,7 @@ publisher:
 # ╰────────────────────────────────────────────────────────────────────────────────────────────────╯
 menu:
   Home: index.html
-  Guidance:
+  Guidelines:
     WHO SMART L1 Basis: who-smart-l1.html
   Artifacts: artifacts.html
 


### PR DESCRIPTION
## Summary
- add a dedicated WHO SMART L1 basis/guidance page for the PH eReferral IG
- link the new guidance page from the home page as an orientation/reference entry point
- add the page to the IG navigation under Guidance

## Related
- Closes #42
- Issue: https://github.com/ph-ereferral-organization/ph-ereferral/issues/42

## Notes
- This PR adds a documentation page only; it does not introduce L2 DAK or L3 technical artifacts.
- Existing baseline IG QA findings unrelated to this page were left unchanged.
