### PR TITLE
chore: rename IG ID to fhir.ph.ereferral

### DIFF
--- a/ig.ini
+++ b/ig.ini
@@ -1,3 +1,3 @@
 [IG]
-ig = fsh-generated/resources/ImplementationGuide-example.fhir.ph.ereferral.json
+ig = fsh-generated/resources/ImplementationGuide-fhir.ph.ereferral.json
 template = fhir.base.template#current

--- a/sushi-config.yaml
+++ b/sushi-config.yaml
@@ -3,7 +3,7 @@
 # │  used properties are included. For a list of all supported properties and their functions,     │
 # │  see: https://fshschool.org/docs/sushi/configuration/.                                         │
 # ╰────────────────────────────────────────────────────────────────────────────────────────────────╯
-id: example.fhir.ph.ereferral
+id: fhir.ph.ereferral
 canonical: urn://example.com/ph-ereferral/fhir
 name: PHeReferralImplementationGuide
 title: PH eReferral Implementation Guide


### PR DESCRIPTION
## Summary
- rename the IG package ID from example.fhir.ph.ereferral to fhir.ph.ereferral
- update ig.ini to point to the renamed generated ImplementationGuide artifact
- regenerate the IG locally to verify the new artifact/package name is produced

## Validation
- ran java -jar input-cache\\publisher.jar -ig . -tx n/a
- confirmed fsh-generated/resources/ImplementationGuide-fhir.ph.ereferral.json is generated
- confirmed the generated IG now contains package ID fhir.ph.ereferral

## Issue
Closes ph-ereferral-organization/ph-ereferral#11

## Notes
- the local IG publisher still reports one pre-existing repo-level validation error because the ImplementationGuide currently has zero defined resources; this PR does not introduce that condition