### PR TITLE
fix: resolve identifier URI conflicts in erefpatient-example.fsh

### DIFF
--- a/input/fsh/aliases.fsh
+++ b/input/fsh/aliases.fsh
@@ -1,5 +1,7 @@
 Alias: $sct = http://snomed.info/sct
 Alias: $loinc = http://loinc.org
+Alias: $PhilHealthID = http://philhealth.gov.ph/fhir/Identifier/philhealth-id
+Alias: $PhilSysID = http://philsys.gov.ph/fhir/Identifier/philsys-id
 Alias: $PSA = https://psa.gov.ph/classification
 Alias: $PSCED = https://psa.gov.ph/classification/psced/level
 Alias: $PSGC = https://psa.gov.ph/classification/psgc

--- a/input/fsh/examples/erefpatient-example.fsh
+++ b/input/fsh/examples/erefpatient-example.fsh
@@ -8,10 +8,10 @@ Title: "ERefPatient Example - Juan Dela Cruz"
 Description: "Example patient instance demonstrating the ERefPatient profile with PhilHealth ID, PhilSys ID, PWD registration, and complete demographic information for eReferral."
 
 // Patient identifiers (PHCorePhilHealthID, PHCorePhilSysID)
-* identifier[PHCorePhilHealthID].system = "https://philhealth.gov.ph/fhir/Identifier/philhealth-id"
+* identifier[PHCorePhilHealthID].system = $PhilHealthID
 * identifier[PHCorePhilHealthID].value = "63-584789845-5"
 
-* identifier[PHCorePhilSysID].system = "https://philsys.gov.ph/the-national-id/"
+* identifier[PHCorePhilSysID].system = $PhilSysID
 * identifier[PHCorePhilSysID].value = "1234-5678-9012-3456"
 
 // Patient name (REF-21)


### PR DESCRIPTION
## Summary
Fix SUSHI build failure caused by identifier URI conflicts in `erefpatient-example.fsh`. The hardcoded identifier system URLs conflicted with canonical URIs defined in the `fhir.ph.core` dependency.

## Related Issue
Closes #51

## Type of Work
- [x] Example
- [ ] Profile
- [ ] ValueSet
- [ ] ConceptMap
- [ ] Narrative Page
- [ ] Test Script
- [ ] PH-Core Dependency Change
- [ ] CI/Build Infrastructure
- [ ] Other

## Changes Made
- Added aliases `$PhilHealthID` and `$PhilSysID` to `input/fsh/aliases.fsh`
- Updated `erefpatient-example.fsh` to use aliases instead of hardcoded URLs
- Changed PhilHealth system from `https://philhealth.gov.ph/fhir/Identifier/philhealth-id` to `http://philhealth.gov.ph/fhir/Identifier/philhealth-id` (matching ph-core)
- Changed PhilSys system from `https://philsys.gov.ph/the-national-id/` to `http://philsys.gov.ph/fhir/Identifier/philsys-id` (matching ph-core)

## Validation / Testing
- [x] IG builds successfully (SUSHI: 0 Errors, 0 Warnings)
- [x] Examples validate
- [ ] Terminology checked (N/A)
- [ ] Links verified
- [ ] Other:

## Reviewer Notes
Please verify:
1. Identifier system URIs align with `fhir.ph.core` canonical definitions
2. Aliases are correctly defined and referenced
3. No other examples have similar hardcoded identifier conflicts

## Preview / Screenshots
**SUSHI build results:**
```
===================================================================
| Ac-clam-ations!                        0 Errors      0 Warnings |
===================================================================
```

**Files changed:**
- `input/fsh/aliases.fsh` - Added 2 new aliases
- `input/fsh/examples/erefpatient-example.fsh` - Updated 2 lines to use aliases