### PR TITLE
feat(ci): implement SUSHI and IG Publisher validation pipeline

### DIFF
--- a/.github/workflows/validate-docs.yml
+++ b/.github/workflows/validate-docs.yml
@@ -1,0 +1,46 @@
+# This CI/CD workflow was derived from the HL7 FHIR IPS project:
+# https://github.com/HL7/fhir-ips/blob/master/.github/workflows/validate-docs.yml
+# Original license: Apache 2.0 (per HL7 FHIR licensing)
+
+name: Validate docs
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+    types: [opened, synchronize] # This will trigger the workflow only when a PR is opened or updated with new commits
+
+jobs:
+  sushi:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Install Sushi
+        run: sudo npm install -g fsh-sushi
+
+      - name: Validate with Sushi
+        run: sushi .
+
+  ig-publisher:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Install Jekyll
+        run: sudo gem install jekyll
+
+      - name: Install Sushi
+        run: sudo npm install -g fsh-sushi
+
+      - name: Install IG publisher
+        run: |
+          chmod +x ./_updatePublisher.sh
+          ./_updatePublisher.sh -y
+
+      - name: Validate IG
+        run: |
+          chmod +x ./_genonce.sh
+          ./_genonce.sh

--- a/.github/workflows/validate-docs.yml
+++ b/.github/workflows/validate-docs.yml
@@ -11,7 +11,31 @@ on:
     types: [opened, synchronize] # This will trigger the workflow only when a PR is opened or updated with new commits
 
 jobs:
+  validate-branch-name:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Validate branch name
+        env:
+          BRANCH_NAME: ${{ github.head_ref || github.ref_name }}
+        run: |
+          echo "Checking branch name: $BRANCH_NAME"
+
+          # Check for forward slash
+          if echo "$BRANCH_NAME" | grep -q '/'; then
+            echo "::error::Branch name contains '/'. Use hyphens instead."
+            exit 1
+          fi
+
+          # Check for other invalid characters
+          if echo "$BRANCH_NAME" | grep -qE '[\\~^:\[\] ]'; then
+            echo "::error::Branch name contains invalid special characters."
+            exit 1
+          fi
+
+          echo "✅ Branch name validation passed"
+
   sushi:
+    needs: validate-branch-name
     runs-on: ubuntu-latest
 
     steps:
@@ -24,6 +48,7 @@ jobs:
         run: sushi .
 
   ig-publisher:
+    needs: validate-branch-name
     runs-on: ubuntu-latest
 
     steps:


### PR DESCRIPTION
## Summary

This PR implements a CI/CD pipeline using GitHub Actions that automatically validates SUSHI compilation and runs IG Publisher checks on pull requests. This addresses the need for automated build validation to catch FSH syntax errors and invalid profile definitions before merging.

The workflow was derived from the [HL7 FHIR IPS project](https://github.com/HL7/fhir-ips/blob/master/.github/workflows/validate-docs.yml) and adapted for this repository.

## Related Issue

Closes #14

## Type of Work

- [ ] Profile
- [ ] ValueSet
- [ ] ConceptMap
- [ ] Example
- [ ] Narrative Page
- [ ] Test Script
- [ ] PH-Core Dependency Change
- [x] CI/Build Infrastructure
- [ ] Other

## Changes Made

- Added .github/workflows/validate-docs.yml with three jobs:

  1. **validate-branch-name job**: Lightweight validation that runs first to check for invalid branch name characters
     - Validates for forward slashes (/), backslashes (\), tildes (~), carets (^), colons (:), square brackets ([ ]), and spaces
     - Uses \"needs: validate-branch-name\" dependency to gate both build jobs
     - Fails fast before any build resources are consumed (no checkout, no dependencies installed)
     - Error messages use GitHub Actions ::error:: annotations for visibility in PR checks

  2. **sushi job**: Validates FSH files compile correctly using fsh-sushi on Ubuntu
     - Depends on validate-branch-name passing first

  3. **ig-publisher job**: Runs full IG Publisher validation including Jekyll site generation
     - Depends on validate-branch-name passing first

- Workflow triggers on:
  - Push to main branch
  - Pull request events (opened, synchronize) for immediate feedback on PR updates
- Added citation comment at top of workflow file attributing the source from HL7 FHIR IPS

## Validation / Testing

- [x] Workflow file is placed in correct location (.github/workflows/)
- [ ] Workflow triggers correctly on pull requests (to be verified after merge)
- [ ] SUSHI compilation passes without errors (to be verified after merge)
- [ ] IG Publisher validation completes successfully (to be verified after merge)
- [x] Source attribution comment included
- [x] Branch naming follows convention (feature-14-sushi-ci-validation)
- [ ] Other:

## Reviewer Notes

Please verify:
- The workflow triggers are appropriate (push to main + PR events)
- Both SUSHI and IG Publisher jobs are defined correctly
- The source attribution comment is properly placed and accurate
- No sensitive information is exposed in the workflow
- Consider the repository size implications noted in [PH Core #127](https://github.com/UP-Manila-SILab/ph-core/issues/127) — this validation workflow does not commit to gh-pages, avoiding size inflation

### Pre-merge Setup Checklist (REQUIRED for Admin) ‼️

Before merging this PR, a repository **admin** must configure the following GitHub settings:

**Repository Settings** (Settings → Actions → General):
- [x] **Actions Enabled**: Select "Allow all actions and reusable workflows"
- [ ] **Workflow Permissions**: Grant "Read and write permissions" (required for actions/checkout)

**Branch Protection** (Settings → Branches →  → Edit protection rules):
- [x] **Require status checks to pass**: Enable "Require status checks to pass before merging"
  - [ ] **Add status checks**: Search and select both:
  - [x] _**Require branches to be up to date**: Recommended to enable_

### Post-merge Verification Steps

After merging, verify the pipeline works by:
1. Confirming the workflow appears in the Actions tab
2. Creating a test PR with a small FSH change (even just a comment)
3. Checking that both checks appear in the PR "Checks" tab
4. Ensuring both jobs complete successfully (green checkmarks)

### Known Limitations / Notes

- **First run will be slower** (~3-5 min) as it downloads IG Publisher (~100MB)
- **Requires internet access** to tx.fhir.org for terminology validation
- **No artifact persistence** configured (build output not saved between runs)
- **Dependencies installed on each run**: SUSHI, Jekyll, and IG Publisher are re-installed fresh on every run

## Related PRs/Issues

- Reference implementation: [PH-RoadSafetyIG workflow](https://github.com/UPM-NTHC/PH-RoadSafetyIG/blob/main/.github/workflows/main.yml)
- Repository size consideration: [PH Core #127](https://github.com/UP-Manila-SILab/ph-core/issues/127)
- Branch name validation pattern from: [PH Core PR #245](https://github.com/UP-Manila-SILab/ph-core/pull/245)

## Preview / Screenshots

N/A — CI/CD infrastructure change only. Workflow results will be visible in the "Checks" tab of future pull requests.