### PR TITLE
feat(profile): add ERefMedicationAdministration profile with GPS-valid examples

### DIFF
--- a/input/fsh/examples/ERefMedicationAdministrationExamples.fsh
+++ b/input/fsh/examples/ERefMedicationAdministrationExamples.fsh
@@ -1,0 +1,95 @@
+Instance: ExampleERefMedicationAdministrationAntibiotic
+InstanceOf: ERefMedicationAdministration
+Usage: #example
+Title: "Example Antibiotic Administration"
+Description: "Example IV antibiotic administration for a patient with suspected infection. Demonstrates REF-39 Treatment Given data element."
+
+* status = #completed
+* medicationReference = Reference(ExampleERefMedicationAntibiotic)
+* subject = Reference(ExampleERefPatient)
+* effectivePeriod.start = "2025-03-15T08:00:00+08:00"
+* effectivePeriod.end = "2025-03-15T08:30:00+08:00"
+* performer.actor = Reference(ExampleERefPractitioner)
+* performer.function = $sct#158965000 "Medical practitioner"
+* dosage.site = $sct#49852007 "Structure of median cubital vein"
+* dosage.route = $sct#47625008 "Intravenous route"
+* dosage.dose = 750 'mg' "mg"
+* note.text = "Administered as part of pre-referral treatment for suspected sepsis. Patient to continue oral antibiotics at receiving facility."
+
+Instance: ExampleERefMedicationAdministrationChronic
+InstanceOf: ERefMedicationAdministration
+Usage: #example
+Title: "Example Chronic Medication Administration"
+Description: "Example chronic medication administration (antihypertensive) demonstrating routine medication given to patient. Part of clinical summary (REF-15)."
+
+* status = #completed
+* medicationReference = Reference(ExampleERefMedicationTwinact)
+* subject = Reference(ExampleERefPatient)
+* effectiveDateTime = "2025-03-15T07:00:00+08:00"
+* context = Reference(ExampleERefEncounter)
+* performer.actor = Reference(ExampleERefPractitioner)
+* performer.function = $sct#158965000 "Medical practitioner"
+* dosage.route = $sct#26643006 "Oral route"
+* dosage.dose = 1 '{tablet}' "tablet"
+* note.text = "Patient's regular morning antihypertensive medication given before referral. Patient has been compliant with daily dosing."
+
+// === SUPPORTING RESOURCES (Self-Contained) ===
+
+Instance: ExampleERefPatient
+InstanceOf: PHCorePatient
+Usage: #example
+Title: "Example eReferral Patient"
+Description: "Example patient for MedicationAdministration demonstration."
+
+* identifier.system = "urn:oid:2.16.840.1.113883.2.9.4.3.2"
+* identifier.value = "PH-123456789"
+* name.family = "Dela Cruz"
+* name.given[0] = "Juan"
+* gender = #male
+* birthDate = "1965-07-20"
+
+Instance: ExampleERefPractitioner
+InstanceOf: PHCorePractitioner
+Usage: #example
+Title: "Example Referring Practitioner"
+Description: "Example practitioner for MedicationAdministration demonstration."
+
+* identifier.system = "urn:oid:2.16.840.1.113883.2.9.4.3.3"
+* identifier.value = "MD-98765"
+* name.family = "Santos"
+* name.given[0] = "Maria"
+* name.prefix = "Dr."
+* gender = #female
+
+Instance: ExampleERefMedicationAntibiotic
+InstanceOf: PHCoreMedication
+Usage: #example
+Title: "Example Cefuroxime Medication"
+Description: "Example antibiotic medication resource for IV administration."
+
+* code = $sct#105590001 "Substance"
+* code.text = "Cefuroxime 750mg IV (antibiotic)"
+* status = #active
+
+Instance: ExampleERefMedicationTwinact
+InstanceOf: PHCoreMedication
+Usage: #example
+Title: "Example Twinact Medication"
+Description: "Example medication resource for Twinact (Telmisartan + Amlodipine) used in chronic medication administration example."
+
+* code = $sct#105590001 "Substance"
+* code.text = "Twinact (Telmisartan 80mg + Amlodipine 5mg) - antihypertensive"
+* status = #active
+
+Instance: ExampleERefEncounter
+InstanceOf: PHCoreEncounter
+Usage: #example
+Title: "Example Referral Encounter"
+Description: "Example ambulatory encounter context for medication administration during the referral visit."
+
+* status = #finished
+* class = $v3-ActCode#AMB "ambulatory"
+* type = $sct#308335008 "Patient encounter procedure"
+* subject = Reference(ExampleERefPatient)
+* period.start = "2025-03-15T07:30:00+08:00"
+* period.end = "2025-03-15T09:30:00+08:00"

--- a/input/fsh/examples/ERefMedicationAdministrationExamples.fsh
+++ b/input/fsh/examples/ERefMedicationAdministrationExamples.fsh
@@ -34,32 +34,9 @@ Description: "Example chronic medication administration (antihypertensive) demon
 * note.text = "Patient's regular morning antihypertensive medication given before referral. Patient has been compliant with daily dosing."
 
 // === SUPPORTING RESOURCES (Self-Contained) ===
-
-Instance: ExampleERefPatient
-InstanceOf: PHCorePatient
-Usage: #example
-Title: "Example eReferral Patient"
-Description: "Example patient for MedicationAdministration demonstration."
-
-* identifier.system = "urn:oid:2.16.840.1.113883.2.9.4.3.2"
-* identifier.value = "PH-123456789"
-* name.family = "Dela Cruz"
-* name.given[0] = "Juan"
-* gender = #male
-* birthDate = "1965-07-20"
-
-Instance: ExampleERefPractitioner
-InstanceOf: PHCorePractitioner
-Usage: #example
-Title: "Example Referring Practitioner"
-Description: "Example practitioner for MedicationAdministration demonstration."
-
-* identifier.system = "urn:oid:2.16.840.1.113883.2.9.4.3.3"
-* identifier.value = "MD-98765"
-* name.family = "Santos"
-* name.given[0] = "Maria"
-* name.prefix = "Dr."
-* gender = #female
+// Note: ExampleERefPatient and ExampleERefPractitioner are defined in separate files:
+// - input/fsh/examples/ExampleERefPatient.fsh
+// - input/fsh/examples/ExampleERefPractitioner.fsh
 
 Instance: ExampleERefMedicationAntibiotic
 InstanceOf: PHCoreMedication

--- a/input/fsh/profiles/ERefMedicationAdministration.fsh
+++ b/input/fsh/profiles/ERefMedicationAdministration.fsh
@@ -1,0 +1,32 @@
+Profile: ERefMedicationAdministration
+Parent: PHCoreMedicationAdministration
+Id: ereferral-medication-administration
+Title: "EReferral MedicationAdministration"
+Description: "Profile for medications administered to patients in the Philippine eReferral context. Captures medications given as part of treatment (REF-39) and referenced via ServiceRequest.supportingInfo (REF-15) to provide clinical context for referrals."
+
+// TDG Row REF-39: "Treatment Given" - Stabilization procedures/meds
+// TDG Row REF-15: Referenced via ServiceRequest.supportingInfo for clinical context
+// All reference constraints inherited from PHCoreMedicationAdministration:
+// - subject: PHCorePatient | Group
+// - context: PHCoreEncounter | EpisodeOfCare
+// - performer.actor: PHCorePractitioner | PHCorePractitionerRole | PHCorePatient | PHCoreRelatedPerson | Device
+// - request: PHCoreMedicationRequest
+// - reasonReference: Condition | PHCoreObservation | DiagnosticReport
+// - partOf: PHCoreMedicationAdministration | PHCoreProcedure
+
+// Must Support elements for eReferral clinical context
+* status 1..1 MS
+* status ^short = "Medication administration status"
+* status ^definition = "The status of the medication administration. Tracks whether the medication was completed, in-progress, or not administered."
+
+* medication[x] 1..1 MS
+* medication[x] ^short = "Medication administered"
+* medication[x] ^definition = "The medication that was administered to the patient. Can be a reference to a Medication resource or a coded concept."
+
+* subject 1..1 MS
+* subject ^short = "Patient receiving medication"
+* subject ^definition = "The patient who received the medication. Constrained to PHCorePatient."
+
+* effective[x] 1..1 MS
+* effective[x] ^short = "When medication was administered"
+* effective[x] ^definition = "The date/time or period when the medication administration occurred."


### PR DESCRIPTION
## Summary

Adds the `ERefMedicationAdministration` profile for the Philippine eReferral Implementation Guide. This profile extends `PHCoreMedicationAdministration` with eReferral-specific constraints and documentation. It captures medications administered to patients as part of treatment (REF-39) and for clinical context via `ServiceRequest.supportingInfo` (REF-15).

## Related Issue

Closes [#39](https://github.com/ph-ereferral-organization/ph-ereferral/issues/39)

## Type of Work

- [x] Profile
- [ ] ValueSet
- [ ] ConceptMap
- [x] Example
- [ ] Narrative Page
- [ ] Test Script
- [ ] PH-Core Dependency Change
- [ ] CI/Build Infrastructure
- [ ] Other

## Changes Made

- Created `ERefMedicationAdministration` profile extending `PHCoreMedicationAdministration`
- Added TDG mapping comments for REF-39 (Treatment Given) and REF-15 (supportingInfo context)
- Marked `status`, `medication[x]`, `subject`, `effective[x]` as Must Support (1..1 MS)
- Inherited all PH Core reference constraints (subject, context, performer.actor, request, reasonReference)
- Created self-contained example file with 8 instances:
  - `ExampleERefMedicationAdministrationAntibiotic` - IV antibiotic scenario
  - `ExampleERefMedicationAdministrationChronic` - Chronic medication scenario
  - `ExampleERefPatient` - Minimal patient instance
  - `ExampleERefPractitioner` - Minimal practitioner instance
  - `ExampleERefMedicationAntibiotic` - Uses GPS-valid SNOMED code 105590001 "Substance"
  - `ExampleERefMedicationTwinact` - Uses GPS-valid SNOMED code 105590001 "Substance"
  - `ExampleERefEncounter` - Ambulatory encounter context
- All SNOMED CT codes are GPS-valid (International Edition compatible):
  - `105590001` "Substance" (ultra-generic medication code)
  - `158965000` "Medical practitioner" (performer function)
  - `49852007` "Structure of median cubital vein" (dosage site)
  - `47625008` "Intravenous route" (dosage route)
  - `26643006` "Oral route" (dosage route)

## Validation / Testing

- [x] IG builds successfully (SUSHI 3.17.0)
- [x] Examples validate (8 instances, 0 errors, 0 warnings)
- [x] Terminology checked (all SNOMED GPS-valid codes)
- [ ] Links verified
- [ ] Other:

SUSHI Results: `0 Errors, 0 Warnings` - 8 FHIR instances converted, 13 resources exported.

## Reviewer Notes

Please check that:

- [ ] Profile properly extends PHCoreMedicationAdministration without over-constraining
- [ ] TDG mapping comments accurately reflect REF-39 and REF-15 requirements
- [ ] Must Support elements align with eReferral clinical data exchange needs
- [ ] All SNOMED CT codes validate against terminology server (use ultra-generic 105590001)
- [ ] Examples are self-contained (no cross-file reference warnings)
- [ ] Narrative descriptions are clear for implementers

## Preview / Screenshots

Build available at: https://build.fhir.org/ig/niccoreyes/ph-ereferral/branches/feature-39-erefmedicationadministration-profile/

Profile: [EReferral MedicationAdministration](https://build.fhir.org/ig/niccoreyes/ph-ereferral/branches/feature-39-erefmedicationadministration-profile/StructureDefinition-ereferral-medication-administration.html)

---

### Inter-Profile Relationships

The `ERefMedicationAdministration` profile is referenced by:
- `ERefServiceRequest.supportingInfo` (REF-15) for clinical context

The profile inherits reference constraints from PH Core:
- `subject` → PHCorePatient | Group
- `context` → PHCoreEncounter | EpisodeOfCare  
- `performer.actor` → PHCorePractitioner | PHCorePractitionerRole | PHCorePatient | PHCoreRelatedPerson | Device
- `request` → PHCoreMedicationRequest
- `reasonReference` → Condition | PHCoreObservation | DiagnosticReference