### PR TITLE
feat(profile): add ERefProvenance profile

### DIFF
--- a/input/fsh/aliases.fsh
+++ b/input/fsh/aliases.fsh
@@ -17,3 +17,5 @@ Alias: $sht = https://icd.who.int/browse10/2019/en#
 Alias: $request-priority = http://hl7.org/fhir/request-priority
 Alias: $servicerequest-status-reason = http://hl7.org/fhir/service-request-status-reason
 Alias: $organization-type = http://terminology.hl7.org/CodeSystem/organization-type
+Alias: $provenance-participant-type = http://terminology.hl7.org/CodeSystem/provenance-participant-type
+Alias: $signature-type = urn:iso-astm:E1762-95:2013

--- a/input/fsh/examples/ERefProvenanceExamples.fsh
+++ b/input/fsh/examples/ERefProvenanceExamples.fsh
@@ -1,0 +1,94 @@
+// === PRIMARY EXAMPLES ===
+
+Instance: ExampleERefProvenanceSignature
+InstanceOf: ERefProvenance
+Usage: #example
+Title: "Example eReferral Provenance with Signature"
+Description: "Provenance record demonstrating professional signature attestation for a referral. Demonstrates REF-3 (Date & Time of Signature) and REF-4 (Professional Signature)."
+
+* target = Reference(ExampleERefServiceRequestMinimal)
+* recorded = "2025-03-15T09:30:00+08:00"
+* activity = $v3-ActCode#CREATE "create"
+* agent[0].type = $provenance-participant-type#author "Author"
+* agent[=].who = Reference(ExampleERefPractitionerRoleMinimal)
+* agent[=].onBehalfOf = Reference(ExampleERefOrganizationMinimal)
+* signature[0].type = $signature-type#1.2.840.10065.1.12.1.5 "Signature"
+* signature[=].when = "2025-03-15T09:30:00+08:00"
+* signature[=].who = Reference(ExampleERefPractitionerRoleMinimal)
+* signature[=].data = "dGVzdHNpZ25hdHVyZWJhc2U2NA=="
+* signature[=].sigFormat = #application/signature+xml
+
+Instance: ExampleERefProvenanceUpdate
+InstanceOf: ERefProvenance
+Usage: #example
+Title: "Example eReferral Provenance for Status Update"
+Description: "Provenance record documenting a referral status update without signature. Demonstrates REF-3 (Date & Time of activity)."
+
+* target = Reference(ExampleERefServiceRequestMinimal)
+* recorded = "2025-03-16T14:22:00+08:00"
+* activity = $v3-ActCode#UPDATE "revise"
+* agent[0].type = $provenance-participant-type#author "Author"
+* agent[=].who = Reference(ExampleERefPractitionerRoleMinimal)
+* agent[=].onBehalfOf = Reference(ExampleERefOrganizationMinimal)
+
+
+// === SUPPORTING RESOURCES (Self-Contained) ===
+
+Instance: ExampleERefPatientMinimal
+InstanceOf: PHCorePatient
+Usage: #example
+Title: "Example eReferral Patient (Minimal)"
+Description: "Minimal patient instance for Provenance demonstration."
+* identifier.system = "urn:oid:2.16.840.1.113883.2.9.4.3.2"
+* identifier.value = "PH-123456789"
+* name.family = "Dela Cruz"
+* name.given[0] = "Juan"
+* gender = #male
+* birthDate = "1965-07-20"
+
+Instance: ExampleERefPractitionerMinimal
+InstanceOf: PHCorePractitioner
+Usage: #example
+Title: "Example Referring Practitioner (Minimal)"
+Description: "Minimal practitioner instance for Provenance demonstration."
+* identifier.system = "urn:oid:2.16.840.1.113883.2.9.4.3.3"
+* identifier.value = "MD-98765"
+* name.family = "Santos"
+* name.given[0] = "Maria"
+* name.prefix = "Dr."
+* gender = #female
+
+Instance: ExampleERefPractitionerRoleMinimal
+InstanceOf: PHCorePractitionerRole
+Usage: #example
+Title: "Example Referring Practitioner Role (Minimal)"
+Description: "Minimal practitioner role instance for Provenance demonstration."
+* active = true
+* practitioner = Reference(ExampleERefPractitionerMinimal)
+* organization = Reference(ExampleERefOrganizationMinimal)
+* code = $sct#158965000 "Medical practitioner"
+
+Instance: ExampleERefOrganizationMinimal
+InstanceOf: PHCoreOrganization
+Usage: #example
+Title: "Example Referring Facility (Minimal)"
+Description: "Minimal organization instance for Provenance demonstration."
+* identifier.system = "http://fhir.nhdr.gov.ph/nhfr/hospcode"
+* identifier.value = "DOH123456"
+* name = "Rural Health Unit - Barangay Health Center"
+* address.line = "123 Health Center Road"
+* address.city = "Quezon City"
+* address.state = "Metro Manila"
+* address.country = "PH"
+
+Instance: ExampleERefServiceRequestMinimal
+InstanceOf: ERefServiceRequest
+Usage: #example
+Title: "Example eReferral Service Request (Minimal)"
+Description: "Minimal service request instance for Provenance demonstration."
+* status = #active
+* intent = #order
+* code = $sct#103695009 "Referral to specialist"
+* subject = Reference(ExampleERefPatientMinimal)
+* authoredOn = "2025-03-15T09:30:00+08:00"
+* requester = Reference(ExampleERefPractitionerRoleMinimal)

--- a/input/fsh/profiles/ERefProvenance.fsh
+++ b/input/fsh/profiles/ERefProvenance.fsh
@@ -1,0 +1,24 @@
+Profile: ERefProvenance
+Parent: PHCoreProvenance
+Id: ereferral-provenance
+Title: "EReferral Provenance"
+Description: "Profile for tracking audit trail of eReferral actions including signatures and timestamps in the Philippine eReferral context."
+
+// TDG Row REF-3: "Date & Time of Signature" -> Provenance.recorded (inherited 1..1 MS from PH Core)
+// TDG Row REF-4: "Professional Signature" -> Provenance.signature with child constraints per issue #31
+
+// Reference constraint: target must be eReferral ServiceRequest
+* target only Reference(ERefServiceRequest)
+
+// Must Support and cardinality for professional signature (REF-4)
+* signature MS
+* signature.type 1..*
+* signature.when 1..1
+* signature.who 1..1
+* signature.data 1..1
+
+// All other Must Support elements inherited from PH Core:
+// - target (1..* MS)
+// - recorded (1..1 MS) - captures REF-3 Date & Time of Signature
+// - agent (1..* MS), agent.who (1..1 MS), agent.type (MS)
+// - activity (MS)


### PR DESCRIPTION
## Summary

Adds the `ERefProvenance` profile for the Philippine eReferral Implementation Guide.
This profile extends `PHCoreProvenance` with eReferral-specific constraints for audit trail tracking.

## Related Issue

Closes #31

## Type of Work

- [x] Profile
- [ ] ValueSet
- [ ] ConceptMap
- [x] Example
- [ ] Narrative Page
- [ ] Test Script
- [ ] PH-Core Dependency Change
- [ ] CI/Build Infrastructure
- [ ] Other

## Changes Made

- Created `ERefProvenance` profile extending `PHCoreProvenance`
- Added TDG mapping comments for:
  - REF-3: "Date & Time of Signature" -> `recorded` (inherited 1..1 MS from PH Core)
  - REF-4: "Professional Signature" -> `signature` with child constraints per issue #31
- Marked `signature` as Must Support (0..* MS)
- Added signature child constraints per issue requirements:
  - `signature.type` 1..*
  - `signature.when` 1..1
  - `signature.who` 1..1
  - `signature.data` 1..1
- Constrained `target` to reference `ERefServiceRequest` only
- Created self-contained example file with 7 instances:
  - `ExampleERefProvenanceSignature` - Professional signature attestation (REF-3, REF-4)
  - `ExampleERefProvenanceUpdate` - Referral status update audit (REF-3)
  - `ExampleERefPatientMinimal` - Minimal patient instance
  - `ExampleERefPractitionerMinimal` - Minimal practitioner instance
  - `ExampleERefPractitionerRoleMinimal` - Minimal practitioner role instance
  - `ExampleERefOrganizationMinimal` - Minimal organization instance
  - `ExampleERefServiceRequestMinimal` - Minimal service request instance
- Added aliases:
  - `$provenance-participant-type` for agent type codes
  - `$signature-type` for signature type codes (FHIR standard)

## Validation / Testing

- [x] IG builds successfully (SUSHI 3.17.0)
- [x] Examples validate (17 instances, 0 errors, 0 warnings)
- [x] Self-contained examples (no cross-file reference warnings)
- [ ] Links verified
- [ ] Other:

**SUSHI Results:** `0 Errors, 0 Warnings` - 17 FHIR instances converted, 26 resources exported.

## Reviewer Notes

Please check that:

- [ ] Profile properly extends PHCoreProvenance without over-constraining
- [ ] TDG mapping comments accurately reflect REF-3 and REF-4 requirements
- [ ] Must Support elements align with eReferral clinical data exchange needs
- [ ] Signature child constraints match issue #31 requirements
- [ ] Examples are self-contained (no cross-file reference warnings)
- [ ] Narrative descriptions are clear for implementers

## Inter-Profile Relationships

The `ERefProvenance` profile:
- Is **referenced by** `ERefServiceRequest.relevantHistory` for audit trail linkage
- **References** `ERefServiceRequest` via the `target` element
- Inherits all PH Core reference constraints:
  - `agent.who` → PHCorePractitioner | PHCorePractitionerRole | PHCoreOrganization | PHCorePatient | PHCoreRelatedPerson
  - `agent.onBehalfOf` → PHCoreOrganization (required when agent is Practitioner or Device per PH Core constraint)
  - `location` → PHCoreLocation