### PR TITLE
Rename Guidelines menu to Guidance

### DIFF
--- a/sushi-config.yaml
+++ b/sushi-config.yaml
@@ -77,7 +77,7 @@ dependencies:
 # ╰────────────────────────────────────────────────────────────────────────────────────────────────╯
 menu:
   Home: index.html
-  Guidelines:
+  Guidance:
     WHO SMART L1 Basis: who-smart-l1.html
   Artifacts: artifacts.html
 


### PR DESCRIPTION
## Summary
Renames the IG menu item from `Guidelines` to `Guidance` in `sushi-config.yaml` to align with the HL7 AU FHIR Core IG naming convention requested in issue #69.

## Related Issue
Closes #69

## Type of Work
- [ ] CI/Build Infrastructure
- [ ] ConceptMap
- [ ] Example
- [ ] Narrative Page
- [ ] PH-Core Dependency Change
- [ ] Profile
- [ ] Test Script
- [ ] ValueSet
- [ ] Extension
- [ ] CodeSystem
- [x] Documentation
- [ ] Other

## Changes Made
Updated the configured IG menu label only:

- `Guidelines` -> `Guidance`
- Kept the existing `WHO SMART L1 Basis` submenu link to `who-smart-l1.html`

## Validation / Testing
- [x] IG builds successfully
- [ ] Examples validate
- [x] Terminology checked
- [x] Links verified
- [x] Other: Confirmed generated menu renders as `Guidance`

Validation performed:

- `sushi.cmd .` completed with `0 Errors`, `0 Warnings`.
- `java -jar input-cache\publisher.jar -ig .` completed and generated the IG.
- Built output reports: `Errors: 10, Warnings: 23, Broken Links: 0`.
- The 10 QA errors and 23 warnings are existing terminology/content validation findings unrelated to the menu label rename.
- Link checking reports `0 broken links`.

## Reviewer Notes
This PR intentionally limits the code change to `sushi-config.yaml`, as requested in issue #69. Existing narrative references to WHO SMART Guidelines and DOH document titles were left unchanged because they are content titles, not the IG menu label.

## Preview / Screenshots
Built menu output renders the top-level dropdown as `Guidance` with `WHO SMART L1 Basis` linking to `who-smart-l1.html`.
https://build.fhir.org/ig/jldalisay95/ph-ereferral-jld/branches/issue-69-guidance-menu/who-smart-l1.html