### PR TITLE
security: update IG template from fhir.base.template to fhir2.base.template

### DIFF
--- a/ig.ini
+++ b/ig.ini
@@ -1,3 +1,3 @@
 [IG]
 ig = fsh-generated/resources/ImplementationGuide-fhir.ph.ereferral.json
-template = fhir.base.template#current
+template = fhir2.base.template#current


### PR DESCRIPTION
## Summary

Updates the IG template from the insecure `fhir.base.template` to the secure `fhir2.base.template` to address the supply chain security vulnerability described in the HL7 FHIR Security Notice (March 17, 2026).

## Related Issue

Closes #65

## Security Context

The `fhir.base.template` package was flagged as insecure due to a dependency confusion attack vulnerability:
- FHIR packages use NPM format but are not published to npmjs.com
- A security researcher demonstrated this vulnerability by creating a malicious package on npmjs.com
- npmjs.com has now blocked `fhir.base.template` to prevent misuse
- The IG Publisher will soon refuse to run for IGs still using the old template

## Changes Made

- Updated `ig.ini`: Changed `template = fhir.base.template#current` → `template = fhir2.base.template#current`

## Type of Work

- [ ] CI/Build Infrastructure
- [ ] ConceptMap
- [ ] Example
- [ ] Narrative Page
- [ ] PH-Core Dependency Change
- [ ] Profile
- [ ] Test Script
- [ ] ValueSet
- [ ] Extension
- [ ] CodeSystem
- [ ] Documentation
- [x] Security Update / Build Configuration

## Validation / Testing

- [x] SUSHI validation passed (0 Errors, 0 Warnings)
- [x] 43 FHIR resources exported successfully
- [x] No references to `fhir.base.template` remain in codebase

SUSHI Results:
```
|  Profiles   |  Extensions  |   Logicals   |   Resources   |
|       6       |      1       |      0       |       0       |
|      ValueSets     |    CodeSystems    |     Instances      |
|         4          |         1         |         31         |
| 0 Errors      0 Warnings |
```

## Source

HL7 FHIR Security Notice, March 17 2026: https://www.fhir.org/guides/security-notices/2026-03-npm-dependencies.html