### PR TITLE
Remove duplicate encounter example

### DIFF
--- a/input/fsh/examples/ERefMedicationAdministrationExamples.fsh
+++ b/input/fsh/examples/ERefMedicationAdministrationExamples.fsh
@@ -34,9 +34,10 @@ Description: "Example chronic medication administration (antihypertensive) demon
 * note.text = "Patient's regular morning antihypertensive medication given before referral. Patient has been compliant with daily dosing."
 
 // === SUPPORTING RESOURCES (Self-Contained) ===
-// Note: ExampleERefPatient and ExampleERefPractitioner are defined in separate files:
+// Note: ExampleERefPatient, ExampleERefPractitioner, and ExampleERefEncounter are defined in separate files:
 // - input/fsh/examples/ExampleERefPatient.fsh
 // - input/fsh/examples/ExampleERefPractitioner.fsh
+// - input/fsh/examples/ExampleERefEncounter.fsh
 
 Instance: ExampleERefMedicationAntibiotic
 InstanceOf: PHCoreMedication
@@ -57,16 +58,3 @@ Description: "Example medication resource for Twinact (Telmisartan + Amlodipine)
 * code = $sct#105590001 "Substance"
 * code.text = "Twinact (Telmisartan 80mg + Amlodipine 5mg) - antihypertensive"
 * status = #active
-
-Instance: ExampleERefEncounter
-InstanceOf: PHCoreEncounter
-Usage: #example
-Title: "Example Referral Encounter"
-Description: "Example ambulatory encounter context for medication administration during the referral visit."
-
-* status = #finished
-* class = $v3-ActCode#AMB "ambulatory"
-* type = $sct#308335008 "Patient encounter procedure"
-* subject = Reference(ExampleERefPatient)
-* period.start = "2025-03-15T07:30:00+08:00"
-* period.end = "2025-03-15T09:30:00+08:00"


### PR DESCRIPTION
## Summary
Removes the duplicate `ExampleERefEncounter` instance from the medication administration examples so SUSHI uses the standalone canonical `input/fsh/examples/ExampleERefEncounter.fsh` definition.

## Related Issue
Closes #85

## Type of Work
- [ ] CI/Build Infrastructure
- [ ] ConceptMap
- [x] Example
- [ ] Narrative Page
- [ ] PH-Core Dependency Change
- [ ] Profile
- [ ] Test Script
- [ ] ValueSet
- [ ] Extension
- [ ] CodeSystem
- [ ] Documentation
- [ ] Other

## Changes Made
- Removed the duplicate `ExampleERefEncounter` block from `input/fsh/examples/ERefMedicationAdministrationExamples.fsh`.
- Updated the supporting-resource comment to note that `ExampleERefEncounter` is defined in `input/fsh/examples/ExampleERefEncounter.fsh`.
- Left the `ExampleERefMedicationAdministrationChronic` reference to `ExampleERefEncounter` intact.

## Validation / Testing
- [x] IG builds successfully
- [x] Examples validate
- [ ] Terminology checked
- [x] Links verified
- [x] Other: `sushi.cmd .` passes with `0 Errors` and `0 Warnings`; `java -jar input-cache\publisher.jar -ig . -tx n/a` completes with exit code 0 and `0 broken links`.

## Reviewer Notes
The issue #85 duplicate-instance error was reproduced before the fix with `sushi.cmd .`. After this change, SUSHI no longer reports `Skipping Instance` or `already exists` for `ExampleERefEncounter`.

The full offline IG Publisher build still reports existing QA validation/terminology items (`9` errors, `49` warnings) unrelated to this duplicate example cleanup.

## Preview / Screenshots
https://build.fhir.org/ig/jldalisay95/ph-ereferral-jld/branches/issue-85-duplicate-eref-encounter/