### PR TITLE
Add v0.1 connectathon readiness guidance

### DIFF
--- a/input/fsh/examples/ERefMedicationAdministrationExamples.fsh
+++ b/input/fsh/examples/ERefMedicationAdministrationExamples.fsh
@@ -34,9 +34,10 @@ Description: "Example chronic medication administration (antihypertensive) demon
 * note.text = "Patient's regular morning antihypertensive medication given before referral. Patient has been compliant with daily dosing."
 
 // === SUPPORTING RESOURCES (Self-Contained) ===
-// Note: ExampleERefPatient and ExampleERefPractitioner are defined in separate files:
+// Note: ExampleERefPatient, ExampleERefPractitioner, and ExampleERefEncounter are defined in separate files:
 // - input/fsh/examples/ExampleERefPatient.fsh
 // - input/fsh/examples/ExampleERefPractitioner.fsh
+// - input/fsh/examples/ExampleERefEncounter.fsh
 
 Instance: ExampleERefMedicationAntibiotic
 InstanceOf: PHCoreMedication
@@ -57,16 +58,3 @@ Description: "Example medication resource for Twinact (Telmisartan + Amlodipine)
 * code = $sct#105590001 "Substance"
 * code.text = "Twinact (Telmisartan 80mg + Amlodipine 5mg) - antihypertensive"
 * status = #active
-
-Instance: ExampleERefEncounter
-InstanceOf: PHCoreEncounter
-Usage: #example
-Title: "Example Referral Encounter"
-Description: "Example ambulatory encounter context for medication administration during the referral visit."
-
-* status = #finished
-* class = $v3-ActCode#AMB "ambulatory"
-* type = $sct#308335008 "Patient encounter procedure"
-* subject = Reference(ExampleERefPatient)
-* period.start = "2025-03-15T07:30:00+08:00"
-* period.end = "2025-03-15T09:30:00+08:00"

--- a/input/pagecontent/connectathon-readiness.md
+++ b/input/pagecontent/connectathon-readiness.md
@@ -1,0 +1,194 @@
+# v0.1 Connectathon Quick-Start, Test Pack, and Release Readiness
+
+This page gives implementers and reviewers a minimum, repeatable path for testing the draft PH eReferral IG v0.1 content from a clean checkout. It separates the testable minimum path from background reference material so connectathon participants can tell the difference between an IG defect, a fixture defect, and a missing instruction.
+
+## v0.1 Quick-Start
+
+| Item | v0.1 expectation |
+|------|------------------|
+| Purpose | Validate the minimum PH eReferral workflow using the IG profiles and examples. |
+| Intended users | IG authors, implementers, vendors, validators, and connectathon testers. |
+| FHIR version | FHIR R4, version `4.0.1`. |
+| IG version | `0.1.0`, release label `ci-build`. |
+| Required dependency | PH Core package `fhir.ph.core` as configured in `sushi-config.yaml`. |
+| Current continuous build | [PH eReferral continuous build](https://build.fhir.org/ig/ph-ereferral-organization/ph-ereferral/). Treat this as a CI build, not a tagged release. |
+| Release tag | No versioned release tag is available yet. Use the [repository tags page](https://github.com/ph-ereferral-organization/ph-ereferral/tags) once issue [#73](https://github.com/ph-ereferral-organization/ph-ereferral/issues/73) is resolved. |
+
+Minimum implementer setup:
+
+1. Git client for cloning the repository.
+2. Node.js and SUSHI for compiling FSH.
+3. Java runtime compatible with the IG Publisher used by this repository.
+4. Ruby/Jekyll where required by the local or CI publisher template.
+5. Network access for first-time package and publisher downloads unless the needed packages are already cached.
+
+## Build and Validate the IG
+
+Clone the repository:
+
+```bash
+git clone https://github.com/ph-ereferral-organization/ph-ereferral.git
+cd ph-ereferral
+```
+
+Compile FSH only:
+
+```bash
+sushi .
+```
+
+Expected SUSHI result:
+
+- `fsh-generated/resources/ImplementationGuide-fhir.ph.ereferral.json` is generated.
+- The summary reports `0 Errors`.
+- If `fhir.ph.core#dev` is not cached locally, SUSHI may fall back to the locally available PH Core package. Record that package state in test evidence.
+
+Run the full IG build on Windows:
+
+```bat
+_genonce.bat
+```
+
+Run the full IG build on macOS or Linux:
+
+```bash
+./_genonce.sh
+```
+
+Run the Publisher directly in offline terminology mode:
+
+```bash
+java -jar input-cache/publisher.jar -ig . -tx n/a
+```
+
+Expected Publisher result:
+
+- `output/index.html` and `output/qa.html` are produced.
+- The command exits successfully.
+- `output/qa.html` is reviewed for errors, warnings, broken links, and terminology limitations before claiming release readiness.
+
+Known build limitations:
+
+- Issue [#73](https://github.com/ph-ereferral-organization/ph-ereferral/issues/73) tracks versioned release infrastructure. Until it is resolved, testers should cite commit hashes or branch build URLs, not a formal release URL.
+- Offline terminology mode can report terminology expansion limitations that must be distinguished from profile or example defects.
+- If the local build uses a cached PH Core package instead of `fhir.ph.core#dev`, record the actual package used in the evidence table.
+
+## Minimum By-Hand Test
+
+Use this as the connectathon smoke test from a clean checkout with the listed fixtures. The expected result is a traceable referral request that moves from creation, to receiving-facility response, to closure.
+
+| Step | Action | Fixture or artifact | Expected result |
+|------|--------|---------------------|-----------------|
+| 1 | Create referral | [Example eReferral ServiceRequest](ServiceRequest-ExampleERefServiceRequest.html) | A referral request exists with `status = active`, `intent = order`, an urgent priority, a patient subject, a requester, a receiving facility, clinical reason, and supporting observations. |
+| 2 | Send referral | [Example eReferral Task - Requested State](Task-ExampleERefTaskRequested.html) | A workflow Task exists with `status = requested`, focused on the ServiceRequest. The requester is populated and the receiving owner is not yet assigned. |
+| 3 | Receive referral | [Example eReferral Task - Accepted State](Task-ExampleERefTaskAccepted.html) | The receiving facility has accepted ownership of the referral Task and `owner` is populated. |
+| 4 | Respond with receiving-facility outcome | [Example eReferral Task - Accepted State](Task-ExampleERefTaskAccepted.html) | For the current v0.1 minimum fixture, the positive receiving response is represented by `Task.status = accepted`. Richer response-state semantics are pending review in issue [#47](https://github.com/ph-ereferral-organization/ph-ereferral/issues/47) and PR [#84](https://github.com/ph-ereferral-organization/ph-ereferral/pull/84). |
+| 5 | Close referral | [Example eReferral Task - Completed State](Task-ExampleERefTaskCompleted.html) and [Example eReferral Encounter](Encounter-ExampleERefEncounter.html) | The Task is completed, completion output is present, and the receiving encounter documents the completed referral encounter. |
+
+Pass criteria for the by-hand test:
+
+- Required examples render in the IG.
+- The ServiceRequest references the patient, requester, receiving facility, reason, and supporting clinical information needed for the scenario.
+- The Task examples preserve a coherent state progression from requested to accepted to completed.
+- The close step records a completion output and a receiving encounter.
+
+Fail criteria:
+
+- A required fixture is missing from the rendered IG.
+- A required reference cannot be followed.
+- The state progression cannot be explained using the current v0.1 artifacts.
+- QA reports a broken link for a required profile, example, or page used in this test.
+
+## Test Data Pack
+
+Required fixtures for the minimum test:
+
+| Fixture | Link | Test role |
+|---------|------|-----------|
+| Referral request | [Example eReferral ServiceRequest](ServiceRequest-ExampleERefServiceRequest.html) | Primary referral order under test. |
+| Patient | [Example eReferral Patient](Patient-ExampleERefPatient.html) | Referral subject. |
+| Referring practitioner | [Example Referring Practitioner](Practitioner-ExampleERefPractitioner.html) | Clinician creating the referral. |
+| Referring practitioner role | [Example Referring Practitioner Role](PractitionerRole-ExampleERefPractitionerRole.html) | Links practitioner to referring facility. |
+| Referring facility | [Example Referring Facility](Organization-ExampleERefReferringFacility.html) | Initiating facility. |
+| Receiving facility | [Example Receiving Hospital](Organization-ExampleERefReceivingHospital.html) | Intended receiving facility. |
+| Clinical condition | [Example Condition - Chest Pain](Condition-ExampleERefConditionChestPain.html) | Referral reason evidence. |
+| Blood pressure observation | [Example Blood Pressure Observation](Observation-ExampleERefObservationBP.html) | Supporting clinical information. |
+| ECG observation | [Example ECG Observation](Observation-ExampleERefObservationECG.html) | Supporting clinical information. |
+| Requested Task | [Example eReferral Task - Requested State](Task-ExampleERefTaskRequested.html) | Sent referral workflow state. |
+| Accepted Task | [Example eReferral Task - Accepted State](Task-ExampleERefTaskAccepted.html) | Receiving-facility response state currently available in v0.1 fixtures. |
+| Completed Task | [Example eReferral Task - Completed State](Task-ExampleERefTaskCompleted.html) | Closed referral state. |
+| Receiving encounter | [Example eReferral Encounter](Encounter-ExampleERefEncounter.html) | Completed referral encounter context. |
+
+Optional fixtures:
+
+| Fixture | Link | Optional use |
+|---------|------|--------------|
+| Provenance signature | [Example eReferral Provenance with Signature](Provenance-ExampleERefProvenanceSignature.html) | Demonstrates signature attestation. |
+| Provenance update | [Example eReferral Provenance for Status Update](Provenance-ExampleERefProvenanceUpdate.html) | Demonstrates status update audit trail. |
+| Medication administration | [Example Chronic Medication Administration](MedicationAdministration-ExampleERefMedicationAdministrationChronic.html) | Clinical summary support. |
+| Antibiotic administration | [Example Antibiotic Administration](MedicationAdministration-ExampleERefMedicationAdministrationAntibiotic.html) | Treatment-given support. |
+| Immunization | [ERefImmunization Example - Routine Immunization](Immunization-ExampleERefImmunizationRoutine.html) | Immunization support. |
+
+## Automated or Semi-Automated Testing
+
+Available checks:
+
+- `sushi .` checks FSH syntax, generates JSON resources, and catches duplicate instance names.
+- `_genonce.bat` or `./_genonce.sh` runs the project build path.
+- `java -jar input-cache/publisher.jar -ig . -tx n/a` runs an offline Publisher build that can be used when terminology server access is slow or unavailable.
+- GitHub Actions runs repository validation on pull requests according to `.github/workflows/validate-docs.yml`.
+
+Not yet available:
+
+- There is no executable connectathon workflow test script that automatically performs create/send/receive/respond/close assertions.
+- There is no multi-server exchange test harness in this repository.
+
+For v0.1, passing the automated build does not replace the by-hand test. It only proves that the IG artifacts can be generated and validated by the available build tooling.
+
+## Test Evidence Summary
+
+Record one row per connectathon run, release candidate, or reviewer verification.
+
+| Evidence field | Value to record |
+|----------------|-----------------|
+| What was tested | Minimum create, send, receive, respond, and close referral path using the fixtures listed above. |
+| Who tested it | Tester name, organization, and role. |
+| Date tested | Calendar date in `YYYY-MM-DD` format. |
+| Build or commit tested | Release tag, branch build URL, or commit SHA. |
+| Build result | SUSHI result, Publisher result, and QA summary. |
+| By-hand test result | Pass, fail, or pass with limitations. |
+| Known unresolved issues | Links to unresolved issues that affect interpretation of the result. |
+
+Current v0.1 readiness status:
+
+- The minimum test path is documented.
+- The fixture set is identified.
+- Formal connectathon execution evidence has not yet been recorded in this repository.
+
+## Known Limitations for v0.1
+
+- Receiving-facility response semantics are still pending review in issue [#47](https://github.com/ph-ereferral-organization/ph-ereferral/issues/47) and PR [#84](https://github.com/ph-ereferral-organization/ph-ereferral/pull/84). The currently published minimum fixture supports requested, accepted, and completed Task states.
+- Non-response and SLA handling are deferred until timing and escalation rules are formally defined.
+- Facility and network identification examples use facility identifiers for testing, but operational registry lookup, HCPN membership, and routing rules are not fully specified in this v0.1 test pack.
+- Attachment exchange, consent, authentication, authorization, transport security, and data-protection controls are outside the current by-hand test.
+- Back-referral is part of the broader policy basis, but it is not included in the minimum v0.1 connectathon path.
+- Multi-server testing has not yet been completed.
+- Versioned release deployment is pending issue [#73](https://github.com/ph-ereferral-organization/ph-ereferral/issues/73).
+
+## Release Readiness Documentation
+
+Use these linked pages when preparing or reviewing a v0.1 release candidate:
+
+- [v0.1 Scope and Release Notes](v01-scope.html)
+- [v0.1 Coverage Map](coverage-map.html)
+- [v0.1 Decision Log and ADR Status](decision-log.html)
+
+Release-readiness checklist for v0.1:
+
+- SUSHI completes with `0 Errors`.
+- The IG Publisher completes and `output/qa.html` is reviewed.
+- Required fixtures in the test data pack render and links are valid.
+- The by-hand test is executed and evidence is recorded.
+- Known limitations are accepted or converted into release blockers.
+- TDG technical review confirms the workflow and terminology interpretation.
+- Product owner review confirms the v0.1 release scope.

--- a/input/pagecontent/coverage-map.md
+++ b/input/pagecontent/coverage-map.md
@@ -1,0 +1,46 @@
+# v0.1 Coverage Map
+
+This page maps the v0.1 minimum referral workflow to the IG artifacts used by the connectathon readiness test.
+
+## Workflow Coverage
+
+| Workflow step | Primary artifact | Supporting artifacts | Coverage status |
+|---------------|------------------|----------------------|-----------------|
+| Create referral | [Example eReferral ServiceRequest](ServiceRequest-ExampleERefServiceRequest.html) | [EReferral ServiceRequest](StructureDefinition-ereferral-service-request.html), patient, practitioner role, organizations, condition, and observations | Covered for the minimum test path. |
+| Send referral | [Example eReferral Task - Requested State](Task-ExampleERefTaskRequested.html) | [EReferral Task](StructureDefinition-ereferral-task.html) and [Example ServiceRequest for Task](ServiceRequest-ExampleERefServiceRequestTask.html) | Covered for a requested referral workflow state. |
+| Receive referral | [Example eReferral Task - Accepted State](Task-ExampleERefTaskAccepted.html) | Receiving organization fixture and Task owner assignment | Covered through the accepted Task fixture. A separate received state is pending review. |
+| Respond with receiving outcome | [Example eReferral Task - Accepted State](Task-ExampleERefTaskAccepted.html) | Issue [#47](https://github.com/ph-ereferral-organization/ph-ereferral/issues/47) and PR [#84](https://github.com/ph-ereferral-organization/ph-ereferral/pull/84) | Partially covered. Positive response is represented by accepted in the current fixture set. Rejected and referred-onward responses are pending review. |
+| Close referral | [Example eReferral Task - Completed State](Task-ExampleERefTaskCompleted.html) | [Example eReferral Encounter](Encounter-ExampleERefEncounter.html) and Task output | Covered for completion of the minimum test path. |
+
+## Profile Coverage
+
+| Profile | v0.1 test role | Link |
+|---------|----------------|------|
+| EReferral ServiceRequest | Primary referral request | [StructureDefinition-ereferral-service-request.html](StructureDefinition-ereferral-service-request.html) |
+| EReferral Task | Workflow state tracking | [StructureDefinition-ereferral-task.html](StructureDefinition-ereferral-task.html) |
+| ERefEncounter | Receiving encounter context | [StructureDefinition-ereferral-encounter.html](StructureDefinition-ereferral-encounter.html) |
+| ERefPatient | Patient profile coverage | [StructureDefinition-ereferral-patient.html](StructureDefinition-ereferral-patient.html) |
+| PH eReferral PractitionerRole | Referring practitioner/facility role | [StructureDefinition-ereferral-practitioner-role.html](StructureDefinition-ereferral-practitioner-role.html) |
+| EReferral Provenance | Audit and signature support | [StructureDefinition-ereferral-provenance.html](StructureDefinition-ereferral-provenance.html) |
+| EReferral MedicationAdministration | Optional clinical summary support | [StructureDefinition-ereferral-medication-administration.html](StructureDefinition-ereferral-medication-administration.html) |
+| ERefImmunization | Optional clinical summary support | [StructureDefinition-ereferral-immunization.html](StructureDefinition-ereferral-immunization.html) |
+
+## Example Coverage
+
+| Example group | Required for minimum path | Notes |
+|---------------|---------------------------|-------|
+| ServiceRequest referral fixture | Yes | Primary referral request. |
+| Task requested, accepted, completed fixtures | Yes | Minimum workflow state progression. |
+| Patient, practitioner, practitioner role, referring facility, receiving facility | Yes | Actor and organization context. |
+| Condition and observations | Yes | Clinical reason and supporting information. |
+| Encounter | Yes | Close step context. |
+| Provenance | Optional | Audit trail and signature support. |
+| MedicationAdministration and Immunization | Optional | Additional clinical summary examples. |
+
+## Gaps and Deferred Coverage
+
+- No automated create/send/receive/respond/close scenario script is present.
+- No multi-server exchange harness is present.
+- Rejected, referred-onward, and explicit received response states are pending review.
+- Non-response and SLA escalation are deferred.
+- Back-referral is not part of the v0.1 minimum connectathon path.

--- a/input/pagecontent/decision-log.md
+++ b/input/pagecontent/decision-log.md
@@ -1,0 +1,25 @@
+# v0.1 Decision Log and ADR Status
+
+This page records the decision status relevant to the v0.1 connectathon readiness guide. It is not a full architectural decision record system; it identifies accepted, provisional, and pending decisions that affect testing.
+
+## Decision Summary
+
+| ID | Decision area | Current status | Decision or working assumption | Reference |
+|----|---------------|----------------|--------------------------------|-----------|
+| D-001 | FHIR version | Accepted for v0.1 | v0.1 uses FHIR R4 `4.0.1`. | `sushi-config.yaml` |
+| D-002 | PH Core dependency | Provisional | The IG depends on `fhir.ph.core: dev`. Local builds may fall back to a cached concrete/current PH Core package if `dev` is not available. | `sushi-config.yaml` |
+| D-003 | Minimum referral request | Accepted for v0.1 testing | ServiceRequest is the primary referral request artifact and Task tracks workflow state. | [EReferral ServiceRequest](StructureDefinition-ereferral-service-request.html), [EReferral Task](StructureDefinition-ereferral-task.html) |
+| D-004 | Minimum by-hand workflow | Accepted for v0.1 testing | The connectathon smoke test uses create, send, receive, respond, and close steps. | [Connectathon readiness guide](connectathon-readiness.html) |
+| D-005 | Receiving-facility response states | Pending review | Current fixtures support requested, accepted, and completed. Richer received, accepted, rejected, and referred-onward semantics are under review. | Issue [#47](https://github.com/ph-ereferral-organization/ph-ereferral/issues/47), PR [#84](https://github.com/ph-ereferral-organization/ph-ereferral/pull/84) |
+| D-006 | Non-response and SLA handling | Deferred | Non-response is out of scope until timing and escalation rules are formally defined. | Issue [#47](https://github.com/ph-ereferral-organization/ph-ereferral/issues/47) |
+| D-007 | Versioned release deployment | Pending | No formal versioned v0.1 release URL or tag is available yet. | Issue [#73](https://github.com/ph-ereferral-organization/ph-ereferral/issues/73) |
+| D-008 | Back-referral | Deferred for this test pack | Back-referral is policy-relevant but is not included in the v0.1 minimum connectathon path. | [WHO SMART L1 Basis](who-smart-l1.html) |
+
+## ADR Status
+
+Formal ADR files are not yet present in this repository. Until ADR files are added, this page should be used as the release-readiness decision index for the v0.1 test pack.
+
+Before tagging a release candidate, reviewers should either:
+
+- confirm that this decision summary is sufficient for v0.1, or
+- create formal ADR files and replace the provisional entries with links to those ADRs.

--- a/input/pagecontent/index.md
+++ b/input/pagecontent/index.md
@@ -56,6 +56,8 @@ This FHIR IG is provided for testing purposes and is not yet suitable for produc
 
 For the narrative and policy foundation of this implementation guide, see [WHO SMART Guidelines L1 Basis for the PH eReferral IG](who-smart-l1.html).
 
+For the minimum v0.1 testing path, build instructions, fixture pack, and release-readiness checklist, see [v0.1 Connectathon Quick-Start, Test Pack, and Release Readiness](connectathon-readiness.html).
+
 ## What is a Use Case IG?
 
 A use case Implementation Guide builds upon foundational and core standards to address a specific clinical or administrative workflow. Unlike base or core IGs that establish broad interoperability foundations, a use case IG:

--- a/input/pagecontent/v01-scope.md
+++ b/input/pagecontent/v01-scope.md
@@ -1,0 +1,57 @@
+# v0.1 Scope and Release Notes
+
+This page records the draft release scope, deferred items, and release-note content used by the v0.1 connectathon readiness guide.
+
+## v0.1 Scope Statement
+
+PH eReferral IG v0.1 defines a minimum FHIR R4 referral path for testing an electronic referral from an initiating facility to a receiving facility. The minimum path uses ServiceRequest for the referral request and Task for workflow state tracking, with supporting Patient, PractitionerRole, Organization, Condition, Observation, Encounter, Provenance, MedicationAdministration, and Immunization examples where available.
+
+v0.1 is a draft testing baseline. It is not a production deployment specification.
+
+## In-Scope Artifacts
+
+| Artifact type | In-scope v0.1 content |
+|---------------|-----------------------|
+| Core referral request | [EReferral ServiceRequest](StructureDefinition-ereferral-service-request.html) |
+| Workflow tracking | [EReferral Task](StructureDefinition-ereferral-task.html) |
+| Encounter context | [ERefEncounter](StructureDefinition-ereferral-encounter.html) |
+| Patient | [ERefPatient](StructureDefinition-ereferral-patient.html) and PH Core Patient examples |
+| Practitioner role | [PH eReferral PractitionerRole](StructureDefinition-ereferral-practitioner-role.html) |
+| Provenance | [EReferral Provenance](StructureDefinition-ereferral-provenance.html) |
+| Medication support | [EReferral MedicationAdministration](StructureDefinition-ereferral-medication-administration.html) |
+| Immunization support | [ERefImmunization](StructureDefinition-ereferral-immunization.html) |
+| Referral terminology | [eReferral Service Category](ValueSet-ereferral-service-category.html), [eReferral Priority](ValueSet-ereferral-priority.html), and [eReferral Reason](ValueSet-ereferral-reason.html) |
+| Test fixtures | Required and optional examples listed in the [connectathon readiness guide](connectathon-readiness.html). |
+
+## Out of Scope or Deferred
+
+| Deferred item | Current v0.1 handling |
+|---------------|-----------------------|
+| Versioned release publication | Pending issue [#73](https://github.com/ph-ereferral-organization/ph-ereferral/issues/73). |
+| Rich receiving-facility response states | Pending review in issue [#47](https://github.com/ph-ereferral-organization/ph-ereferral/issues/47) and PR [#84](https://github.com/ph-ereferral-organization/ph-ereferral/pull/84). |
+| Non-response and SLA escalation | Deferred until timing and escalation rules are formally defined. |
+| Back-referral | Not included in the v0.1 minimum test path. |
+| Multi-server connectathon harness | Not yet available. |
+| Attachment exchange and security workflow | Outside the current v0.1 by-hand test. |
+| Operational facility directory and HCPN routing | Not fully specified in this v0.1 test pack. |
+
+## Change Log
+
+| Version or build | Status | Notes |
+|------------------|--------|-------|
+| `0.1.0` / `ci-build` | Draft | Initial connectathon readiness baseline with build instructions, by-hand test path, fixture list, known limitations, and release-readiness references. |
+
+## Release Tag
+
+No formal v0.1 release tag is available yet. When the release management work is complete, link the tagged release from this page and update the [connectathon readiness guide](connectathon-readiness.html).
+
+## Release Candidate Checklist
+
+- Release branch or tag exists and is recorded.
+- `sushi .` completes with `0 Errors`.
+- Full IG Publisher build completes and `output/qa.html` is reviewed.
+- Required test fixtures render and links are valid.
+- Connectathon by-hand test evidence is recorded.
+- Known limitations are accepted by reviewers or moved to release blockers.
+- TDG technical review is complete.
+- Product owner release-readiness review is complete.

--- a/sushi-config.yaml
+++ b/sushi-config.yaml
@@ -79,6 +79,10 @@ menu:
   Home: index.html
   Guidance:
     WHO SMART L1 Basis: who-smart-l1.html
+    v0.1 Connectathon Readiness: connectathon-readiness.html
+    v0.1 Scope and Release Notes: v01-scope.html
+    v0.1 Coverage Map: coverage-map.html
+    v0.1 Decision Log: decision-log.html
   Artifacts: artifacts.html
 
 # ╭───────────────────────────Less Common Implementation Guide Properties──────────────────────────╮


### PR DESCRIPTION
﻿## Summary
Adds a v0.1 connectathon readiness documentation set that gives implementers a repeatable minimum test path from a clean checkout. The PR also removes the duplicate `ExampleERefEncounter` instance that blocked clean SUSHI output.

## Related Issue
Fixes #78
Fixes #85

Related/supporting issues referenced by the new pages: #73, #57, #58, #47, #41, #20.

## Type of Work
- [ ] CI/Build Infrastructure
- [ ] ConceptMap
- [x] Example
- [x] Narrative Page
- [ ] PH-Core Dependency Change
- [ ] Profile
- [ ] Test Script
- [ ] ValueSet
- [ ] Extension
- [ ] CodeSystem
- [x] Documentation
- [ ] Other

## Changes Made
- Added `connectathon-readiness.md` with the v0.1 quick-start, build/validation commands, minimum by-hand test path, fixture list, pass/fail criteria, known limitations, and release-readiness checklist.
- Added supporting v0.1 scope/release notes, coverage map, and decision-log pages.
- Linked the new readiness material from the home page and Guidance menu.
- Removed the duplicate `ExampleERefEncounter` definition from `ERefMedicationAdministrationExamples.fsh` and left the standalone encounter fixture as the canonical definition.
- Left `.github/workflows/validate-docs.yml` unchanged from `main`; the PR intentionally retains the existing `chmod +x ./_genonce.sh` and `./_genonce.sh` validation step.

## Validation / Testing
- [x] IG builds successfully
- [x] Examples validate
- [ ] Terminology checked
- [x] Links verified
- [x] Other: `sushi.cmd .` completed locally with `0 Errors` and `0 Warnings`.

Additional local Publisher check from this branch:

- `java -jar input-cache\publisher.jar -ig . -tx n/a`
- Result: build completed; QA reported remaining offline/pre-existing validation items and `0 broken links`.

## Reviewer Notes
Reviewers should focus on whether the minimum by-hand test path is sufficiently explicit for connectathon participants, whether the required fixture pack is complete, and whether the deferred v0.1 limitations are accurately represented.

The GitHub Actions validation workflow is intentionally unchanged in this PR.

## Preview / Screenshots
https://build.fhir.org/ig/jldalisay95/ph-ereferral-jld/branches/issue-78-connectathon-readiness/en/connectathon-readiness.html

Preview after CI publishes the branch build:

- `connectathon-readiness.html`
- `v01-scope.html`
- `coverage-map.html`
- `decision-log.html`
