### PR TITLE
Pr 77 local test

### DIFF
--- a/.github/workflows/validate-docs.yml
+++ b/.github/workflows/validate-docs.yml
@@ -1,18 +1,23 @@
 # This CI/CD workflow was derived from the HL7 FHIR IPS project:
 # https://github.com/HL7/fhir-ips/blob/master/.github/workflows/validate-docs.yml
 # Original license: Apache 2.0 (per HL7 FHIR licensing)
+# Modified to follow linear build pattern from PH Core IG
 
-name: Validate docs
+name: Build PH eReferral FHIR IG
 
 on:
-  push:
-    branches: [ main ]
   pull_request:
-    types: [opened, synchronize] # This will trigger the workflow only when a PR is opened or updated with new commits
+    branches: [main]
+  push:
+    branches: [main]
+
+permissions:
+  contents: write
 
 jobs:
-  validate-branch-name:
+  build:
     runs-on: ubuntu-latest
+
     steps:
       - name: Validate branch name
         env:
@@ -34,38 +39,41 @@ jobs:
 
           echo "✅ Branch name validation passed"
 
-  sushi:
-    needs: validate-branch-name
-    runs-on: ubuntu-latest
+      - uses: actions/checkout@v4
 
-    steps:
-      - uses: actions/checkout@v3
+      - name: Install dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y graphviz
+          sudo gem install jekyll
+          sudo npm install -g fsh-sushi
 
-      - name: Install Sushi
-        run: sudo npm install -g fsh-sushi
-
-      - name: Validate with Sushi
-        run: sushi .
-
-  ig-publisher:
-    needs: validate-branch-name
-    runs-on: ubuntu-latest
-
-    steps:
-      - uses: actions/checkout@v3
-
-      - name: Install Jekyll
-        run: sudo gem install jekyll
-
-      - name: Install Sushi
-        run: sudo npm install -g fsh-sushi
-
-      - name: Install IG publisher
+      - name: Build IG
         run: |
           chmod +x ./_updatePublisher.sh
           ./_updatePublisher.sh -y
-
-      - name: Validate IG
-        run: |
           chmod +x ./_genonce.sh
           ./_genonce.sh
+
+      - name: QA Gate
+        run: |
+          if [ -f output/qa.json ]; then
+            ERRORS=$(grep -o '"errs":[0-9]*' output/qa.json | grep -o '[0-9]*' || echo "0")
+            if [ "$ERRORS" -gt 0 ]; then
+              echo "::error::QA errors found: $ERRORS"
+              exit 1
+            fi
+            echo "✅ QA passed: $ERRORS errors"
+          else
+            echo "::warning::No qa.json found"
+          fi
+
+      - name: Deploy to GitHub Pages
+        if: always() && github.event_name == 'push'
+        uses: peaceiris/actions-gh-pages@v4
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          publish_branch: gh-pages
+          publish_dir: ./output
+          single_commit: true
+          commit_message: "Deploy IG - ${{ github.sha }}"

--- a/.github/workflows/validate-docs.yml
+++ b/.github/workflows/validate-docs.yml
@@ -58,7 +58,7 @@ jobs:
       - name: QA Gate
         run: |
           if [ -f output/qa.json ]; then
-            ERRORS=$(grep -o '"errs":[0-9]*' output/qa.json | grep -o '[0-9]*' || echo "0")
+            ERRORS=$(jq -r '.errs // 0' output/qa.json)
             if [ "$ERRORS" -gt 0 ]; then
               echo "::error::QA errors found: $ERRORS"
               exit 1

--- a/.github/workflows/validate-docs.yml
+++ b/.github/workflows/validate-docs.yml
@@ -75,5 +75,5 @@ jobs:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           publish_branch: gh-pages
           publish_dir: ./output
-          single_commit: true
+          force_orphan:  true
           commit_message: "Deploy IG - ${{ github.sha }}"

--- a/_build.bat
+++ b/_build.bat
@@ -25,38 +25,54 @@ IF EXIST "%input_cache_path%%publisher_jar%" (
     ) ELSE (
         SET "jar_location=not_found"
         SET "default_choice=1"
+        SET "default_reason=publisher not found"
         ECHO publisher.jar not found in input-cache or parent folder
     )
 )
 
 
 :: Handle command-line argument to bypass the menu
-IF NOT "%~1"=="" (
-    IF /I "%~1"=="update" SET "userChoice=1"
-    IF /I "%~1"=="build" SET "userChoice=2"
-    IF /I "%~1"=="nosushi" SET "userChoice=3"
-    IF /I "%~1"=="notx" SET "userChoice=4"
-    IF /I "%~1"=="jekyll" SET "userChoice=5"
-    IF /I "%~1"=="clean" SET "userChoice=6"
-    IF /I "%~1"=="exit" SET "userChoice=0"
-    GOTO executeChoice
-)
+:: Known first arguments select a menu option; anything else is passed through to the publisher
+SET "extraArgs="
+IF "%~1"=="" GOTO showMenu
+IF /I "%~1"=="update" SET "userChoice=1" & GOTO parseExtra
+IF /I "%~1"=="build" SET "userChoice=2" & GOTO parseExtra
+IF /I "%~1"=="nosushi" SET "userChoice=3" & GOTO parseExtra
+IF /I "%~1"=="notx" SET "userChoice=4" & GOTO parseExtra
+IF /I "%~1"=="jekyll" SET "userChoice=5" & GOTO parseExtra
+IF /I "%~1"=="clean" SET "userChoice=6" & GOTO parseExtra
+IF /I "%~1"=="exit" SET "userChoice=0" & GOTO parseExtra
+:: Unknown first arg - default to build, pass all args through
+SET "userChoice=2"
+GOTO collectArgs
+:parseExtra
+SHIFT
+:collectArgs
+IF "%~1"=="" GOTO executeChoice
+SET "extraArgs=!extraArgs! %1"
+SHIFT
+GOTO collectArgs
+:showMenu
 
 echo ---------------------------------------------------------------
 ECHO Checking internet connection...
 PING tx.fhir.org -4 -n 1 -w 4000 >nul 2>&1 && SET "online_status=true" || SET "online_status=false"
 
 IF "%online_status%"=="true" (
-    ECHO We're online and tx.fhir.org is available.
+    ECHO We are online and tx.fhir.org is available.
     FOR /F "tokens=2 delims=:" %%a IN ('curl -s https://api.github.com/repos/HL7/fhir-ig-publisher/releases/latest ^| findstr "tag_name"') DO SET "latest_version=%%a"
     SET "latest_version=!latest_version:"=!"
     SET "latest_version=!latest_version: =!"
     SET "latest_version=!latest_version:~0,-1!"
 ) ELSE (
-    ECHO We're offline or tx.fhir.org is not available, can only run the publisher without TX...
+    ECHO.
+    ECHO *** WARNING: Working offline - this is not the normal mode.
+    ECHO     Some features including terminology rendering will not work.
+    ECHO.
     SET "txoption=-tx n/a"
     SET "latest_version=unknown"
     SET "default_choice=4"
+    SET "default_reason=working offline"
 )
 
 echo ---------------------------------------------------------------
@@ -74,14 +90,16 @@ IF NOT "%jar_location%"=="not_found" (
 ECHO Publisher version: !publisher_version!; Latest is !latest_version!
 
 IF NOT "%online_status%"=="true" (
-   ECHO We're offline.
+   ECHO We are offline.
 ) ELSE (
     IF NOT "!publisher_version!"=="!latest_version!" (
         ECHO An update is recommended.
         SET "default_choice=1"
+        SET "default_reason=newer version available"
     ) ELSE (
         ECHO Publisher is up to date.
         SET "default_choice=2"
+        SET "default_reason=publisher is up to date"
     )
 )
 
@@ -96,12 +114,9 @@ echo 4. Build IG - force no TX server
 echo 5. Jekyll build
 echo 6. Clean up temp directories
 echo 0. Exit
-:: echo [Press Enter for default (%default_choice%) or type an option number:]
 echo.
 
-:: Using CHOICE to handle input with timeout
-:: ECHO [Enter=Continue, 1-7=Option, 0=Exit]
-choice /C 12345670 /N /CS /D %default_choice% /T 5 /M "Choose an option number or wait 5 seconds for default (%default_choice%):"
+choice /C 12345670 /N /CS /D %default_choice% /T 5 /M "Choose an option number or wait 5 seconds for default (%default_choice% - %default_reason%):"
 SET "userChoice=%ERRORLEVEL%"
 
 
@@ -115,15 +130,12 @@ IF "%userChoice%"=="4" GOTO publish_notx
 IF "%userChoice%"=="5" GOTO debugjekyll
 IF "%userChoice%"=="6" GOTO clean
 IF "%userChoice%"=="0" EXIT /B
-
-:end
-
-
+GOTO endscript
 
 :debugjekyll
     echo Running Jekyll build...
     jekyll build -s temp/pages -d output
-GOTO end
+GOTO endscript
 
 
 :clean
@@ -152,10 +164,7 @@ GOTO end
         echo Removed: .\template
     )
 
-GOTO end
-
-
-
+GOTO endscript
 
 
 :downloadpublisher
@@ -198,7 +207,7 @@ IF DEFINED FORCE (
 	GOTO download
 )
 
-IF "%skipPrompts%"=="y" (
+IF "%skipPrompts%"=="true" (
 	SET create=Y
 ) ELSE (
 	SET /p create="Download? (Y/N) "
@@ -211,7 +220,7 @@ IF /I "%create%"=="Y" (
 GOTO done
 
 :upgrade
-IF "%skipPrompts%"=="y" (
+IF "%skipPrompts%"=="true" (
 	SET overwrite=Y
 ) ELSE (
 	SET /p overwrite="Overwrite %jarlocation%? (Y/N) "
@@ -265,7 +274,7 @@ GOTO done
 
 ECHO.
 ECHO Updating scripts
-IF "%skipPrompts%"=="y" (
+IF "%skipPrompts%"=="true" (
 	SET updateScripts=Y
 ) ELSE (
 	SET /p updateScripts="Update scripts? (Y/N) "
@@ -273,7 +282,7 @@ IF "%skipPrompts%"=="y" (
 IF /I "%updateScripts%"=="Y" (
 	GOTO scripts
 )
-GOTO end
+GOTO endscript
 
 
 :scripts
@@ -299,12 +308,12 @@ ECHO Updating _build.bat
 call POWERSHELL -command if ('System.Net.WebClient' -as [type]) {(new-object System.Net.WebClient).DownloadFile(\"%build_bat_url%\",\"_build.new.bat\") } else { Invoke-WebRequest -Uri "%build_bat_url%" -Outfile "_build.new.bat" }
 if %ERRORLEVEL% == 0 goto upd_script_2
 echo "Errors encountered during download: %errorlevel%"
-goto end
+goto endscript
 :upd_script_2
 start copy /y "_build.new.bat" "_build.bat" ^&^& del "_build.new.bat" ^&^& exit
 
 
-GOTO end
+GOTO endscript
 
 
 :publish_once
@@ -312,14 +321,15 @@ GOTO end
 SET JAVA_TOOL_OPTIONS=-Dfile.encoding=UTF-8
 
 :: Debugging statements before running publisher
-ECHO 1jar_location is: %jar_location%
+ECHO jar_location is: %jar_location%
 IF NOT "%jar_location%"=="not_found" (
-	java %JAVA_OPTS% -jar "%jar_location%" -ig . %txoption% %*
+	ECHO IG Publisher FOUND, Publishing...
+	java %JAVA_OPTS% -jar "%jar_location%" -ig . %txoption% %extraArgs%
 ) ELSE (
-	ECHO IG Publisher NOT FOUND in input-cache or parent folder.  Please run _updatePublisher.  Aborting...
+	ECHO IG Publisher NOT FOUND in input-cache or parent folder.  Please run the script and update the publisher.  Aborting...
 )
 
-GOTO end
+GOTO endscript
 
 
 
@@ -328,14 +338,14 @@ GOTO end
 SET JAVA_TOOL_OPTIONS=-Dfile.encoding=UTF-8
 
 :: Debugging statements before running publisher
-ECHO 3jar_location is: %jar_location%
+ECHO jar_location is: %jar_location%
 IF NOT "%jar_location%"=="not_found" (
-	java %JAVA_OPTS% -jar "%jar_location%" -ig . %txoption% -no-sushi %*
+	java %JAVA_OPTS% -jar "%jar_location%" -ig . %txoption% -no-sushi %extraArgs%
 ) ELSE (
-	ECHO IG Publisher NOT FOUND in input-cache or parent folder. Please run _updatePublisher.  Aborting...
+	ECHO IG Publisher NOT FOUND in input-cache or parent folder. Please run the script and update the publisher.  Aborting...
 )
 
-GOTO end
+GOTO endscript
 
 
 :publish_notx
@@ -344,43 +354,33 @@ SET txoption=-tx n/a
 SET JAVA_TOOL_OPTIONS=-Dfile.encoding=UTF-8
 
 :: Debugging statements before running publisher
-ECHO 2jar_location is: %jar_location%
+ECHO jar_location is: %jar_location%
 IF NOT "%jar_location%"=="not_found" (
-	java %JAVA_OPTS% -jar "%jar_location%" -ig . %txoption% %*
+	java %JAVA_OPTS% -jar "%jar_location%" -ig . %txoption% %extraArgs%
 ) ELSE (
-	ECHO IG Publisher NOT FOUND in input-cache or parent folder.  Please run _updatePublisher.  Aborting...
+	ECHO IG Publisher NOT FOUND in input-cache or parent folder.  Please run the script and update the publisher.  Aborting...
 )
 
-GOTO end
-
-
+GOTO endscript
 
 
 :publish_continuous
 
 SET JAVA_TOOL_OPTIONS=-Dfile.encoding=UTF-8
 
-:: Debugging statements before running publisher
-ECHO Checking %input_cache_path% for publisher.jar
-IF EXIST "%input_cache_path%\%publisher_jar%" (
-	java %JAVA_OPTS% -jar "%input_cache_path%\%publisher_jar%" -ig . %txoption% -watch %*
+ECHO jar_location is: %jar_location%
+IF NOT "%jar_location%"=="not_found" (
+	java %JAVA_OPTS% -jar "%jar_location%" -ig . %txoption% -watch %extraArgs%
 ) ELSE (
-    ECHO Checking %upper_path% for publisher.jar
-    IF EXIST "..\%publisher_jar%" (
-	    java %JAVA_OPTS% -jar "..\%publisher_jar%" -ig . %txoption% -watch %*
-    ) ELSE (
-	    ECHO IG Publisher NOT FOUND in input-cache or parent folder.  Please run _updatePublisher.  Aborting...
-    )
+	ECHO IG Publisher NOT FOUND in input-cache or parent folder.  Please run the script and update the publisher.  Aborting...
 )
 
-GOTO end
+GOTO endscript
 
 
-:end
+:endscript
 
 :: Pausing at the end
-
-
 IF NOT "%skipPrompts%"=="true" (
   PAUSE
 )

--- a/_build.sh
+++ b/_build.sh
@@ -26,20 +26,44 @@ function check_jar_location() {
 }
 
 function check_internet_connection() {
-  if ping -c 1 tx.fhir.org &>/dev/null; then
+  local target="tx.fhir.org"
+  local reachable=false
+
+  if command -v ping > /dev/null 2>&1; then
+    if ping -c 1 -W 5 "$target" > /dev/null 2>&1 \
+    || ping -c 1 -w 5 "$target" > /dev/null 2>&1; then
+      reachable=true
+    fi
+  elif command -v curl > /dev/null 2>&1; then
+    if curl --silent --max-time 5 --output /dev/null "https://$target"; then
+      reachable=true
+    fi
+  else
+    echo "WARNING: Neither ping nor curl available — assuming offline."
+  fi
+
+  if [ "$reachable" = "true" ]; then
     online=true
-    echo "We're online and tx.fhir.org is available."
+    echo "We're online and $target is available."
     latest_version=$(curl -s https://api.github.com/repos/HL7/fhir-ig-publisher/releases/latest | grep tag_name | cut -d'"' -f4)
   else
     online=false
-    echo "We're offline or tx.fhir.org is unavailable."
+    echo ""
+    echo "⚠️  WARNING: Working offline — this is not the normal mode."
+    echo "   Some features (e.g. terminology rendering) will not work."
+    echo ""
   fi
 }
 
 
+
 function update_publisher() {
   echo "Publisher jar location: ${input_cache_path}${publisher_jar}"
-  read -p "Download or update publisher.jar? (Y/N): " confirm
+  if [ "$skipPrompts" = "true" ]; then
+    confirm="Y"
+  else
+    read -p "Download or update publisher.jar? (Y/N): " confirm
+  fi
   if [[ "$confirm" =~ ^[Yy]$ ]]; then
     echo "Downloading latest publisher.jar (~200 MB)..."
     mkdir -p "$input_cache_path"
@@ -53,7 +77,11 @@ function update_publisher() {
 
 
 function update_scripts_prompt() {
-  read -p "Update scripts (_build.bat and _build.sh)? (Y/N): " update_confirm
+  if [ "$skipPrompts" = "true" ]; then
+    update_confirm="Y"
+  else
+    read -p "Update scripts (_build.bat and _build.sh)? (Y/N): " update_confirm
+  fi
   if [[ "$update_confirm" =~ ^[Yy]$ ]]; then
     echo "Updating scripts..."
     curl -L "$build_bat_url" -o "_build.new.bat" && mv "_build.new.bat" "_build.bat"
@@ -66,33 +94,35 @@ function update_scripts_prompt() {
 }
 
 
-function build_ig() {
+function run_publisher() {
+  local extra_flags=("$@")
   if [ "$jar_location" != "not_found" ]; then
-    args=()
-    if [ "$online" = "false" ]; then
-      args+=("-tx" "n/a")
-    fi
-    java -Dfile.encoding=UTF-8 -jar "$jar_location" -ig . "${args[@]}" "$@"
+    echo "jar_location is: $jar_location"
+    export JAVA_TOOL_OPTIONS="-Dfile.encoding=UTF-8"
+    java $JAVA_OPTS -jar "$jar_location" -ig . "${extra_flags[@]}"
   else
-    echo "publisher.jar not found. Please run update."
+    echo "IG Publisher NOT FOUND in input-cache or parent folder. Please run update. Aborting..."
   fi
 }
 
+function build_ig() {
+  local args=()
+  if [ "$online" = "false" ]; then
+    args+=("-tx" "n/a")
+  fi
+  run_publisher "${args[@]}" "$@"
+}
 
 function build_nosushi() {
-  if [ "$jar_location" != "not_found" ]; then
-    java -Dfile.encoding=UTF-8 -jar "$jar_location" -ig . -no-sushi "$@"
-  else
-    echo "publisher.jar not found. Please run update."
-  fi
+  run_publisher -no-sushi "$@"
 }
 
 function build_notx() {
-  if [ "$jar_location" != "not_found" ]; then
-    java -Dfile.encoding=UTF-8 -jar "$jar_location" -ig . -tx n/a "$@"
-  else
-    echo "publisher.jar not found. Please run update."
-  fi
+  run_publisher -tx n/a "$@"
+}
+
+function build_continuous() {
+  run_publisher -watch "$@"
 }
 
 function jekyll_build() {
@@ -113,64 +143,78 @@ function cleanup() {
 }
 
 check_jar_location
+
+# Handle command-line arguments
+# Known first arguments select a menu option; anything else is passed through to the publisher
+extraArgs=()
+if [ $# -gt 0 ]; then
+  case "$1" in
+    update)  shift; extraArgs=("$@"); update_publisher; exit 0 ;;
+    build)   shift; extraArgs=("$@"); check_internet_connection; build_ig "${extraArgs[@]}"; exit 0 ;;
+    nosushi) shift; extraArgs=("$@"); check_internet_connection; build_nosushi "${extraArgs[@]}"; exit 0 ;;
+    notx)    shift; extraArgs=("$@"); build_notx "${extraArgs[@]}"; exit 0 ;;
+    jekyll)  jekyll_build; exit 0 ;;
+    clean)   cleanup; exit 0 ;;
+    exit)    exit 0 ;;
+    *)
+      # Unknown first arg - default to build, pass all args through
+      extraArgs=("$@")
+      run_publisher "${extraArgs[@]}"
+      exit 0
+      ;;
+  esac
+fi
+
+# Interactive menu
 check_internet_connection
 
-# Handle command-line argument or menu
-case "$1" in
-  update) update_publisher ;;
-  build) build_ig ;;
-  nosushi) build_nosushi ;;
-  notx) build_notx ;;
-  jekyll) jekyll_build ;;
-  clean) cleanup ;;
-  exit) exit 0 ;;
-  *)
-    # Compute default choice
-    default_choice=2 # Build by default
+# Compute default choice and reason
+default_choice=2
+default_reason="publisher is up to date"
 
-    if [ "$jar_location" = "not_found" ]; then
-      default_choice=1 # Download if jar is missing
-    elif [ "$online" = "false" ]; then
-      default_choice=4 # Offline build
-    elif [ -n "$latest_version" ]; then
-      current_version=$(java -jar "$jar_location" -v 2>/dev/null | tr -d '\r')
-      if [ "$current_version" != "$latest_version" ]; then
-        default_choice=1 # Offer update if newer version exists
-      fi
-    fi
+if [ "$jar_location" = "not_found" ]; then
+  default_choice=1
+  default_reason="publisher not found"
+elif [ "$online" = "false" ]; then
+  default_choice=4
+  default_reason="working offline"
+elif [ -n "$latest_version" ]; then
+  current_version=$(java -jar "$jar_location" -v 2>/dev/null | tr -d '\r')
+  if [ "$current_version" != "$latest_version" ]; then
+    default_choice=1
+    default_reason="newer version available"
+  fi
+fi
 
-    echo "---------------------------------------------"
-    echo "Publisher: ${current_version:-unknown}; Latest: ${latest_version:-unknown}"
-    echo "Publisher location: $jar_location"
-    echo "Online: $online"
-    echo "---------------------------------------------"
-    echo
-    echo "Please select an option:"
-    echo "1) Download or update publisher"
-    echo "2) Build IG"
-    echo "3) Build IG without Sushi"
-    echo "4) Build IG without TX server"
-    echo "5) Jekyll build"
-    echo "6) Cleanup temp directories"
-    echo "0) Exit"
-    echo
+echo "---------------------------------------------"
+echo "Publisher: ${current_version:-unknown}; Latest: ${latest_version:-unknown}"
+echo "Publisher location: $jar_location"
+echo "Online: $online"
+echo "---------------------------------------------"
+echo
+echo "Please select an option:"
+echo "1) Download or update publisher"
+echo "2) Build IG"
+echo "3) Build IG without Sushi"
+echo "4) Build IG without TX server"
+echo "5) Jekyll build"
+echo "6) Cleanup temp directories"
+echo "0) Exit"
+echo
 
-    # Read with timeout, but default if nothing entered
-    echo -n "Choose an option [default: $default_choice]: "
-    read -t 5 choice || choice="$default_choice"
-    choice="${choice:-$default_choice}"
-    echo "You selected: $choice"
+# Read with timeout, but default if nothing entered
+echo -n "Choose an option [default: $default_choice - $default_reason]: "
+read -t 5 choice || choice="$default_choice"
+choice="${choice:-$default_choice}"
+echo "You selected: $choice"
 
-    case "$choice" in
-      1) update_publisher ;;
-      2) build_ig ;;
-      3) build_nosushi ;;
-      4) build_notx ;;
-      5) jekyll_build ;;
-      6) cleanup ;;
-      0) exit 0 ;;
-      *) echo "Invalid option." ;;
-    esac
-  ;;
-
+case "$choice" in
+  1) update_publisher ;;
+  2) build_ig ;;
+  3) build_nosushi ;;
+  4) build_notx ;;
+  5) jekyll_build ;;
+  6) cleanup ;;
+  0) exit 0 ;;
+  *) echo "Invalid option." ;;
 esac

--- a/input/fsh/aliases.fsh
+++ b/input/fsh/aliases.fsh
@@ -9,6 +9,7 @@ Alias: $PSOC = https://psa.gov.ph/classification/psoc/unit
 Alias: $v2-0203 = http://terminology.hl7.org/CodeSystem/v2-0203
 Alias: $v3-ActCode = http://terminology.hl7.org/CodeSystem/v3-ActCode
 Alias: $condition-clinical = http://terminology.hl7.org/CodeSystem/condition-clinical
+Alias: $condition-ver-status = http://terminology.hl7.org/CodeSystem/condition-ver-status
 Alias: $observation-category = http://terminology.hl7.org/CodeSystem/observation-category
 Alias: $v3-ObservationInterpretation = http://terminology.hl7.org/CodeSystem/v3-ObservationInterpretation
 Alias: $allergyintolerance-clinical = http://terminology.hl7.org/CodeSystem/allergyintolerance-clinical

--- a/input/fsh/examples/ExampleERefConditionChestPain.fsh
+++ b/input/fsh/examples/ExampleERefConditionChestPain.fsh
@@ -4,7 +4,7 @@ Usage: #example
 Title: "Example Condition - Chest Pain"
 Description: "Example chest pain condition for referral"
 * clinicalStatus = $condition-clinical#active
-* verificationStatus = $sct#provisional "Provisional"
+* verificationStatus = $condition-ver-status#provisional "Provisional"
 * category = $sct#439401001 "Diagnosis"
 * severity = $sct#24484000 "Severe"
 * code = $sct#29857009 "Chest pain"

--- a/input/fsh/examples/ExampleERefPractitioner.fsh
+++ b/input/fsh/examples/ExampleERefPractitioner.fsh
@@ -11,4 +11,4 @@ Description: "Example referring practitioner"
 * name.given[+] = "Clara"
 * name.prefix = "Dr."
 * gender = #female
-* qualification.code = $sct#1062931000119102 "Doctor of Medicine"
+* qualification.code = $sct#158965000 "Medical practitioner"

--- a/input/fsh/examples/ExampleERefServiceRequest.fsh
+++ b/input/fsh/examples/ExampleERefServiceRequest.fsh
@@ -5,9 +5,9 @@ Title: "Example eReferral Service Request"
 Description: "An example referral request from a rural health unit to a tertiary hospital for cardiology consultation."
 * status = #active
 * intent = #order
-* category = $sct#103695009 "Referral to specialist"
+* category = $sct#3457005 "Patient referral"
 * priority = #urgent
-* code = $sct#183519001 "Referral to cardiology service"
+* code = $sct#183519002 "Referral to cardiology service"
 * subject = Reference(ExampleERefPatient)
 * authoredOn = "2025-03-15T09:30:00+08:00"
 * requester = Reference(ExampleERefPractitionerRole)

--- a/sushi-config.yaml
+++ b/sushi-config.yaml
@@ -4,7 +4,7 @@
 # │  see: https://fshschool.org/docs/sushi/configuration/.                                         │
 # ╰────────────────────────────────────────────────────────────────────────────────────────────────╯
 id: fhir.ph.ereferral
-canonical: urn://example.com/ph-ereferral/fhir
+canonical: https://example.com/ph-ereferral/fhir
 name: PHeReferralImplementationGuide
 title: PH eReferral Implementation Guide
 description: This implementation guide is provided to support the use of FHIR®© in an Philippines context, and defines the minimum set of constraints on the FHIR resources to create the PH eReferral profiles. This implementation guide forms the foundation to build future PH Realm FHIR implementation guides and its content will continue to grow to meet the needs of PH implementers.
@@ -25,7 +25,7 @@ publisher:
 # use cases, the value can be an object with keys for id, uri, and version.
 #
 dependencies:
-  fhir.ph.core: dev
+  fhir.ph.core: current
 #   hl7.fhir.us.core: 3.1.0
 #   hl7.fhir.us.mcode:
 #     id: mcode


### PR DESCRIPTION
## Summary
Fix the rollback branch so CI can validate successfully in a fresh GitHub Actions environment.

This updates the implementation guide configuration to use a valid HTTPS canonical URL and a resolvable PH Core dependency reference. The goal is to preserve the rollback PR’s intent—a stable CI baseline—while making the build reproducible in CI.

## Related Issue
Refs #56, #57, #58, #74

## Type of Work
- [x] CI/Build Infrastructure
- [x] PH-Core Dependency Change
- [ ] ConceptMap
- [x] Example
- [ ] Narrative Page
- [ ] Profile
- [ ] Test Script
- [ ] ValueSet
- [ ] Extension
- [ ] CodeSystem
- [ ] Documentation
- [ ] Other

## Changes Made
Updated `sushi-config.yaml` to address the configuration drift causing CI failures:

1. **Canonical URL**
   - Changed from `urn://example.com/ph-ereferral/fhir`
   - Changed to `https://example.com/ph-ereferral/fhir`

   This avoids publisher validation issues related to the invalid URN protocol format for the IG canonical.

2. **PH Core dependency**
   - Changed from `fhir.ph.core: dev`
   - Changed to `fhir.ph.core: current`

   This aligns the build with the currently resolvable PH Core package and avoids the broken/non-reproducible dependency state seen in CI and local testing when trying to pin to an unavailable `0.1.0` package.

These changes keep the rollback branch aligned with its original purpose—restoring a working baseline—while making the result reproducible in a clean environment.

## Validation / Testing
- [x] IG builds successfully
- [x] Examples validate
- [x] Terminology checked
- [ ] Links verified
- [x] Other: `sushi .` completed with 0 errors and 0 warnings
- [x] Other: Full IG Publisher run completed with `Errors: 0, Warnings: 12, Info: 59, Broken Links: 0`

## Reviewer Notes
Please focus review on:
- whether changing the canonical from `urn://` to `https://` is acceptable for this IG
- whether `fhir.ph.core: current` is the correct short-term dependency choice for restoring CI reproducibility
- whether this should be merged as a stabilization fix now, with a follow-up PR to replace `example.com` with the project’s real canonical URL

This PR does **not** change the overall intent of #77. It fixes the branch so the rollback baseline can actually pass in GitHub Actions.

## Preview / Screenshots
Local validation result after the config fix:

- `sushi .` → **0 errors, 0 warnings**
- IG Publisher → **Errors: 0, Warnings: 12, Info: 59, Broken Links: 0**

Relevant final publisher output:

- `Validation output in /mnt/d/projects/ph-ereferral/output/qa.html`
- `Errors: 0, Warnings: 12, Info: 59, Broken Links: 0`