### PR TITLE
fix(profile): update parent of ERefServiceRequest to PHCoreServiceRequest

### DIFF
--- a/input/fsh/profiles/ERefServiceRequest.fsh
+++ b/input/fsh/profiles/ERefServiceRequest.fsh
@@ -1,5 +1,5 @@
 Profile: ERefServiceRequest
-Parent: ServiceRequest
+Parent: PHCoreServiceRequest
 Id: ereferral-service-request
 Title: "EReferral ServiceRequest"
 Description: "Profile for ServiceRequest resource in the Philippine eReferral context. This profile defines the core referral request structure for referring patients between healthcare facilities."


### PR DESCRIPTION

## Summary
Changed the parent of ERefServiceRequest to PHCoreServiceRequest

## Related Issue
Closes #103 

## Type of Work
- [ ] CI/Build Infrastructure
- [ ] ConceptMap
- [ ] Example
- [ ] Narrative Page
- [ ] PH-Core Dependency Change
- [ ] Profile
- [ ] Test Script
- [ ] ValueSet
- [ ] Extension
- [ ] CodeSystem
- [ ] Documentation
- [ ] Other

## Changes Made
Line 2 of ERefServiceRequest.fsh changed from "Parent:  ServiceRequest" to "Parent: PHCoreServiceRequest"

## Validation / Testing
- [ ] IG builds successfully
- [ ] Examples validate
- [ ] Terminology checked
- [ ] Links verified
- [ ] Other:

## Reviewer Notes
Key areas reviewers should focus on.

## Preview / Screenshots
See rendered page here: https://build.fhir.org/ig/eabuenaventura/eab-ph-ereferral/branches/103-update-erefservicerequest-parent-to-phcore/en/