### PR TITLE
docs: integrate fhirpatterns.net pattern references into AGENTS.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -33,6 +33,8 @@
 - macOS/Linux: `./_build.sh clean`
 - Windows: `_build.bat clean`
 
+> **Pattern:** [Local Build Parity](https://fhirpatterns.net/ig-authoring-patterns/patterns/local-build-parity/) — The equivalent macOS/Linux/Windows build scripts above follow this pattern: every developer should be able to reproduce the CI build locally. See also [GitHub Actions Pipeline](https://fhirpatterns.net/ig-authoring-patterns/patterns/github-actions-pipeline/) for the CI workflow structure in `.github/workflows/`.
+
 ## Architecture
 
 - **Type**: FHIR R4 Implementation Guide using SUSHI/FSH
@@ -54,6 +56,8 @@
 - **Branch naming**: Use hyphens, never slashes (e.g., `feat-name` not `feat/name`)
 - **Profile prefix**: Use `ERef` prefix for eReferral-specific profiles (e.g., `ERefPatient`, `ERefServiceRequest`)
 
+> **Patterns:** [Standard IG Layout](https://fhirpatterns.net/ig-authoring-patterns/patterns/standard-ig-layout/) governs the `input/` directory structure used here. [FSH Authoring — Aliases and RuleSets](https://fhirpatterns.net/ig-authoring-patterns/patterns/aliases-and-rulesets/) and [Extensions and Slicing](https://fhirpatterns.net/ig-authoring-patterns/patterns/extensions-and-slicing/) cover FSH best practices. For profiling decisions, apply [Profile Minimalism with Justification](https://fhirpatterns.net/fhir-authoring-patterns/patterns/pl-12/) and [Example-Driven Profiling](https://fhirpatterns.net/fhir-authoring-patterns/patterns/pl-14/) — constrain only what is clinically necessary, and drive profile shape from concrete examples. See also [FSH-First, Repo-First Authoring](https://fhirpatterns.net/fhir-authoring-patterns/patterns/pl-06/) and [Package-First IG Layout](https://fhirpatterns.net/fhir-authoring-patterns/patterns/pl-07/) for the broader authoring philosophy this repo follows.
+
 ## Contribution Workflow
 
 1. Check for existing issue or create one using templates
@@ -61,6 +65,8 @@
 3. Reference issue in commits: `git commit -m "Description (#48)"`
 4. Open PR linking to issue: `Fixes #48`
 5. Merge only when CI is green, use squash merge, delete branch after
+
+> **Patterns:** Issue and PR structure follows [Issue Templates](https://fhirpatterns.net/ig-authoring-patterns/patterns/issue-templates/) and [PR Templates & CODEOWNERS](https://fhirpatterns.net/ig-authoring-patterns/patterns/pr-templates-and-codeowners/). Each issue type maps to a structured artifact with a [Definition-of-Done per Artifact](https://fhirpatterns.net/fhir-authoring-patterns/patterns/pl-05/) checklist.
 
 ## Dependencies
 
@@ -73,9 +79,43 @@ This IG extends the **PH Core IG** (`fhir.ph.core`). For the complete and curren
 - **Validation**: Review `output/qa.html` for errors, warnings, and broken links
 - **PH Core dependency issues**: Ensure `fhir.ph.core` package is downloaded (run `sushi .` to auto-download)
 
+> **Pattern:** [Auto-Builder vs Local Builds](https://fhirpatterns.net/ig-authoring-patterns/patterns/auto-builder-vs-local/) covers the trade-offs between relying on the HL7 auto-builder and maintaining local build parity — relevant when diagnosing differences between local output and CI/published results.
+
 ## Resources
 
 - **PH eReferral Repository**: https://github.com/ph-ereferral-organization/ph-ereferral
 - **PH Core Repository**: https://github.com/UP-Manila-SILab/ph-core
 - **Publisher**: https://github.com/HL7/fhir-ig-publisher
 - **SUSHI/FSH**: https://fshschool.org/
+
+## FHIR Pattern References
+
+This IG applies patterns from the [FHIR Pattern Languages](https://fhirpatterns.net/) — a collection of reusable guidance for healthcare interoperability. Agents and contributors should consult these patterns when making structural, authoring, or tooling decisions.
+
+### IG Authoring Patterns ([full catalog](https://fhirpatterns.net/ig-authoring-patterns/introduction/pattern-catalog/))
+
+| Pattern | Relevance to this repo |
+|---|---|
+| [Standard IG Layout](https://fhirpatterns.net/ig-authoring-patterns/patterns/standard-ig-layout/) | `input/` directory structure, file placement conventions |
+| [Local Build Parity](https://fhirpatterns.net/ig-authoring-patterns/patterns/local-build-parity/) | `_genonce.sh` / `_build.sh` scripts match CI behaviour |
+| [GitHub Actions Pipeline](https://fhirpatterns.net/ig-authoring-patterns/patterns/github-actions-pipeline/) | `.github/workflows/validate-docs.yml` CI pipeline |
+| [Issue Templates](https://fhirpatterns.net/ig-authoring-patterns/patterns/issue-templates/) | Structured issue types in `.github/ISSUE_TEMPLATE/` |
+| [PR Templates & CODEOWNERS](https://fhirpatterns.net/ig-authoring-patterns/patterns/pr-templates-and-codeowners/) | PR checklist and review ownership |
+| [Aliases and RuleSets](https://fhirpatterns.net/ig-authoring-patterns/patterns/aliases-and-rulesets/) | FSH alias and RuleSet conventions in `input/fsh/` |
+| [Extensions and Slicing](https://fhirpatterns.net/ig-authoring-patterns/patterns/extensions-and-slicing/) | Extension definitions and slicing discipline |
+| [Auto-Builder vs Local Builds](https://fhirpatterns.net/ig-authoring-patterns/patterns/auto-builder-vs-local/) | When to use HL7 auto-builder vs local publisher |
+| [SemVer and Release Channels](https://fhirpatterns.net/ig-authoring-patterns/patterns/semver-and-channels/) | Versioning strategy for IG releases |
+
+### FHIR Authoring Patterns ([full catalog](https://fhirpatterns.net/fhir-authoring-patterns/introduction/pattern-catalog/))
+
+| Pattern | Relevance to this repo |
+|---|---|
+| [FSH-First, Repo-First Authoring](https://fhirpatterns.net/fhir-authoring-patterns/patterns/pl-06/) | All FHIR artifacts defined in FSH; repo is the source of truth |
+| [Package-First IG Layout](https://fhirpatterns.net/fhir-authoring-patterns/patterns/pl-07/) | `sushi-config.yaml` and package structure |
+| [Definition-of-Done per Artifact](https://fhirpatterns.net/fhir-authoring-patterns/patterns/pl-05/) | DoD checklists in issue templates and PRs |
+| [Profile Minimalism with Justification](https://fhirpatterns.net/fhir-authoring-patterns/patterns/pl-12/) | Constrain only what is clinically required; document why |
+| [Example-Driven Profiling](https://fhirpatterns.net/fhir-authoring-patterns/patterns/pl-14/) | Examples in `input/fsh/examples/` drive profile shape |
+
+### FHIR Implementation Patterns ([full catalog](https://fhirpatterns.net/fhir-implementation-patterns/introduction/pattern-catalog/))
+
+Patterns from this language are relevant for future referral system integration work (e.g., service discovery, capability negotiation, async invocation). Consult the catalog when designing inter-system interactions beyond the IG itself.


### PR DESCRIPTION
Closes #105

## Summary

- Adds a new **FHIR Pattern References** section to `AGENTS.md` with tables covering IG Authoring, FHIR Authoring, and FHIR Implementation patterns
- Adds inline `> **Pattern:**` cross-references to all four relevant existing sections: Build Commands, Code Style & Conventions, Contribution Workflow, and Debugging Tips

## Definition-of-Done checklist

- [x] AGENTS.md contains a new "FHIR Pattern References" section linking to fhirpatterns.net
- [x] Build Commands section cross-references Local Build Parity and GitHub Actions Pipeline
- [x] Code Style & Conventions section cross-references FSH Authoring and Standard IG Layout
- [x] Contribution Workflow section cross-references Issue Templates and PR Templates & CODEOWNERS
- [x] Debugging Tips section cross-references Auto-Builder vs Local Builds
- [x] AGENTS.md updated and renders correctly
- [x] All new links verified (no broken links — all point to live fhirpatterns.net pages)
- [x] At least one pattern from each relevant category referenced (IG Authoring: 9, FHIR Authoring: 5, FHIR Implementation: catalog linked)
- [x] Build parity maintained (documentation-only change, no CI changes required)

🤖 Generated with [Claude Code](https://claude.com/claude-code)