### PR TITLE
ci: auto-assign PR creator as assignee for org members (#112)

### DIFF
--- a/.github/workflows/auto-assign-pr.yml
+++ b/.github/workflows/auto-assign-pr.yml
@@ -1,0 +1,23 @@
+name: Auto-assign PR author
+
+on:
+  pull_request:
+    types: [opened]
+
+jobs:
+  auto-assign:
+    runs-on: ubuntu-latest
+    if: |
+      (github.event.pull_request.author_association == 'MEMBER' ||
+       github.event.pull_request.author_association == 'OWNER')
+      && github.event.pull_request.user.type != 'Bot'
+    permissions:
+      pull-requests: write
+    steps:
+      - name: Assign PR to author
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          gh pr edit ${{ github.event.pull_request.number }} \
+            --add-assignee ${{ github.event.pull_request.user.login }} \
+            --repo ${{ github.repository }}


### PR DESCRIPTION
## Summary
Add a GitHub Actions workflow that automatically assigns the PR creator as assignee when a PR is opened, but only if the creator is a member or owner of the organization.

## Related Issue
Closes #112

## Type of Work
- [x] CI/Build Infrastructure
- [ ] ConceptMap
- [ ] Example
- [ ] Narrative Page
- [ ] PH-Core Dependency Change
- [ ] Profile
- [ ] Test Script
- [ ] ValueSet
- [ ] Extension
- [ ] CodeSystem
- [ ] Documentation
- [ ] Other

## Changes Made
- Added `.github/workflows/auto-assign-pr.yml`
- Trigger: `pull_request` event with type `opened`
- Condition: `author_association` is `MEMBER` or `OWNER`, and `user.type` is not `Bot`
- Permission: `pull-requests: write` (uses default `GITHUB_TOKEN`)
- Action: `gh pr edit --add-assignee <author>`

## Validation / Testing
- [ ] IG builds successfully
- [ ] Examples validate
- [ ] Terminology checked
- [ ] Links verified
- [x] Other: workflow syntax validated via `actionlint` / GitHub Actions parser

## Reviewer Notes
- `author_association` is set by GitHub based on the user's role in the organization at the time the PR is opened. No PAT or extra API call is needed.
- Bots are explicitly skipped via `user.type != 'Bot'` to avoid noise.

## Preview / Screenshots
N/A — no IG content changes.
