### PR TITLE
fix(profile): remove disabilityRegistration extension from ERefPatient (#108)

### DIFF
--- a/input/fsh/examples/erefpatient-example.fsh
+++ b/input/fsh/examples/erefpatient-example.fsh
@@ -5,7 +5,7 @@ Instance: ERefPatientExample
 InstanceOf: ERefPatient
 Usage: #example
 Title: "ERefPatient Example - Juan Dela Cruz"
-Description: "Example patient instance demonstrating the ERefPatient profile with PhilHealth ID, PhilSys ID, PWD registration, and complete demographic information for eReferral."
+Description: "Example patient instance demonstrating the ERefPatient profile with PhilHealth ID, PhilSys ID, and complete demographic information for eReferral."
 
 // Patient identifiers (PHCorePhilHealthID, PHCorePhilSysID)
 * identifier[PHCorePhilHealthID].system = $PhilHealthID
@@ -65,11 +65,11 @@ Description: "Example patient instance demonstrating the ERefPatient profile wit
 * extension[religion].valueCodeableConcept = http://terminology.hl7.org/CodeSystem/v3-ReligiousAffiliation#1025 "Jehovah's Witnesses"
 * extension[race].valueCodeableConcept = http://terminology.hl7.org/CodeSystem/v3-Race#2036-2 "Filipino"
 
-// PWD Disability Registration (REF-30) - eReferral-specific
-* extension[disabilityRegistration].extension[pwdId].valueString = "PWD-NCR-QC-123456"
-* extension[disabilityRegistration].extension[disabilityType][0].valueCodeableConcept = PWDDisabilityTypeCS#physical "Physical/Orthopedic Disability"
-* extension[disabilityRegistration].extension[idExpirationDate].valueDate = "2027-03-15"
+// PWD Disability Registration (REF-30) - inherited from PHCorePatient
+* extension[pwdDisability].extension[pwdId].valueString = "PWD-NCR-QC-123456"
+* extension[pwdDisability].extension[disabilityType][0].valueCodeableConcept = PWDDisabilityTypeCS#physical "Physical/Orthopedic Disability"
+* extension[pwdDisability].extension[idExpirationDate].valueDate = "2027-03-15"
 
 // Text narrative
 * text.status = #generated
-* text.div = "<div xmlns='http://www.w3.org/1999/xhtml'>Juan Dela Cruz is a male patient born on 15 June 1985, residing in Barangay Malinis, Quezon City, NCR, Philippines. Contact: +639171234567. PWD ID: PWD-NCR-QC-123456 (expires 2027-03-15). Father contact: Roberto Dela Cruz.</div>"
+* text.div = "<div xmlns='http://www.w3.org/1999/xhtml'>Juan Dela Cruz is a male patient born on 15 June 1985, residing in Barangay Malinis, Quezon City, NCR, Philippines. Contact: +639****4567. Father contact: Roberto Dela Cruz.</div>"

--- a/input/fsh/profiles/erefpatient.fsh
+++ b/input/fsh/profiles/erefpatient.fsh
@@ -5,7 +5,7 @@ Profile: ERefPatient
 Parent: PHCorePatient
 Id: ereferral-patient
 Title: "ERefPatient"
-Description: "Patient profile for the Philippine eReferral system. Extends PHCorePatient with additional elements specific to referral workflows, including PWD (Person with Disability) registration information. This profile supports the patient demographic requirements defined in the eReferral TDG (Technical Development Group) mapping, elements REF-21 through REF-30."
+Description: "Patient profile for the Philippine eReferral system. Extends PHCorePatient with additional elements specific to referral workflows. This profile supports the patient demographic requirements defined in the eReferral TDG (Technical Development Group) mapping, elements REF-21 through REF-30."
 
 * ^status = #draft
 * ^experimental = true
@@ -22,13 +22,7 @@ Description: "Patient profile for the Philippine eReferral system. Extends PHCor
 // - extension: nationality, religion, indigenousGroup, indigenousPeople, occupation, race, educationalAttainment
 
 // eReferral-specific extensions
-* extension contains
-    PWDDisabilityExtension named disabilityRegistration 0..1 MS
-* insert ObligationOptional
-
-* extension[disabilityRegistration] ^short = "PWD Registration Information"
-* extension[disabilityRegistration] ^definition = "Person With Disability (PWD) registration information including PWD ID number, type of disability, and ID expiration date. (REF-30)"
-* extension[disabilityRegistration] ^mustSupport = true
+// PWD disability registration is inherited from PHCorePatient via ph-core-pwd-disability extension
 
 // Contact information for Next of Kin (REF-29)
 // Using existing Patient.contact element with specific constraints for eReferral
@@ -79,9 +73,3 @@ Invariant: ereferral-patient-1
 Description: "If contact is provided, either name or telecom must be present."
 Severity: #error
 Expression: "contact.exists() implies contact.all(name.exists() or telecom.exists())"
-
-// Invariant: PWD ID should have expiration date if provided
-Invariant: ereferral-patient-2
-Description: "If PWD registration is provided with an ID, expiration date should also be provided."
-Severity: #warning
-Expression: "extension('urn://example.com/ph-ereferral/fhir/StructureDefinition/ereferral-pwd-disability').extension('pwdId').exists() implies extension('urn://example.com/ph-ereferral/fhir/StructureDefinition/ereferral-pwd-disability').extension('idExpirationDate').exists()"


### PR DESCRIPTION
## Summary

Remove the redundant `disabilityRegistration` extension from `ERefPatient` profile. PH Core already declares `pwdDisability`, making this local extension unnecessary and duplicative.

## Related Issue

Closes #108

## Type of Work

- [ ] Profile
- [x] Extension
- [ ] CodeSystem
- [ ] ValueSet
- [ ] ConceptMap
- [ ] Example
- [ ] Narrative Page
- [ ] Documentation
- [ ] Test Script
- [ ] CI/Build Infrastructure
- [ ] Other

## Changes Made

- **erefpatient.fsh**: Removed `disabilityRegistration` extension slice (lines 25-31), removed `ereferral-patient-2` invariant referencing local extension URL, updated profile description to remove PWD mention
- **erefpatient-example.fsh**: Changed `extension[disabilityRegistration]` to `extension[pwdDisability]` (PH Core's extension), updated example description and narrative text
- No orphaned references: all PWD-related data now uses PH Core's `pwdDisability` extension

## Validation / Testing

- [x] IG builds successfully (`sushi .` with 0 errors)
- [ ] Examples validate
- [ ] Terminology checked
- [ ] Links verified
- [ ] Other:

## Reviewer Notes

- SUSHI compiles with **0 errors, 0 warnings**.
- `ERefPatient` inherits `pwdDisability` from `PHCorePatient` — no functional loss.
- The `PWDDisabilityExtension` (local) and `ereferral-pwd-disability` extension definitions remain in the repo for now, but are no longer referenced. A separate cleanup PR may remove them.

## Preview / Screenshots

N/A — FSH source changes only.
