### PR TITLE
[Profile] Add ERefDiagnosticReport for Laboratory Results and Diagnostic Imaging

### DIFF
--- a/input/fsh/examples/ERefDiagnosticReportExamples.fsh
+++ b/input/fsh/examples/ERefDiagnosticReportExamples.fsh
@@ -1,0 +1,20 @@
+Instance: ExampleERefDiagnosticReportPDF
+InstanceOf: ERefDiagnosticReport
+Usage: #example
+Title: "Example Laboratory Diagnostic Report with PDF Attachment"
+Description: "Example laboratory DiagnosticReport associated with an eReferral and carrying complete report attachment metadata in presentedForm."
+
+* status = #final
+* category = http://terminology.hl7.org/CodeSystem/v2-0074#LAB "Laboratory"
+* code = $loinc#11502-2 "Laboratory report"
+* basedOn = Reference(ExampleERefServiceRequest)
+* subject = Reference(ERefPatientExample)
+* effectiveDateTime = "2025-03-15T08:30:00+08:00"
+* issued = "2025-03-15T10:00:00+08:00"
+* performer = Reference(ExampleERefReferringFacility)
+* conclusion = "Laboratory report completed and attached for referral review."
+* presentedForm.contentType = #application/pdf
+* presentedForm.url = "https://example.org/fhir/reports/laboratory-report-2025-001.pdf"
+* presentedForm.size = 245760
+* presentedForm.title = "Laboratory Report 2025-001"
+* presentedForm.creation = "2025-03-15T10:00:00+08:00"

--- a/input/fsh/examples/ERefDiagnosticReportExamples.fsh
+++ b/input/fsh/examples/ERefDiagnosticReportExamples.fsh
@@ -2,19 +2,13 @@ Instance: ExampleERefDiagnosticReportPDF
 InstanceOf: ERefDiagnosticReport
 Usage: #example
 Title: "Example Laboratory Diagnostic Report with PDF Attachment"
-Description: "Example laboratory DiagnosticReport associated with an eReferral and carrying complete report attachment metadata in presentedForm."
+Description: "Example laboratory DiagnosticReport with complete report attachment through presentedForm, linked to an eReferral ServiceRequest and patient."
 
 * status = #final
-* category = http://terminology.hl7.org/CodeSystem/v2-0074#LAB "Laboratory"
 * code = $loinc#11502-2 "Laboratory report"
 * basedOn = Reference(ExampleERefServiceRequest)
 * subject = Reference(ERefPatientExample)
-* effectiveDateTime = "2025-03-15T08:30:00+08:00"
-* issued = "2025-03-15T10:00:00+08:00"
 * performer = Reference(ExampleERefReferringFacility)
-* conclusion = "Laboratory report completed and attached for referral review."
 * presentedForm.contentType = #application/pdf
 * presentedForm.url = "https://example.org/fhir/reports/laboratory-report-2025-001.pdf"
-* presentedForm.size = 245760
 * presentedForm.title = "Laboratory Report 2025-001"
-* presentedForm.creation = "2025-03-15T10:00:00+08:00"

--- a/input/fsh/profiles/ERefDiagnosticReport.fsh
+++ b/input/fsh/profiles/ERefDiagnosticReport.fsh
@@ -1,0 +1,71 @@
+// PH Core does not currently publish a DiagnosticReport profile, so this
+// eReferral profile derives directly from the FHIR R4 base resource.
+// TDG REF-40 maps laboratory result attachments to presentedForm and links
+// the report from ServiceRequest.supportingInfo.
+Profile: ERefDiagnosticReport
+Parent: DiagnosticReport
+Id: ereferral-diagnostic-report
+Title: "EReferral DiagnosticReport"
+Description: "Diagnostic report profile for laboratory, diagnostic imaging, pathology, and histopathology reports shared as supporting clinical information in a Philippine eReferral."
+
+* ^status = #draft
+* ^experimental = true
+* ^purpose = "To support referral handover of diagnostic reports that summarize or group diagnostic findings, link to structured atomic Observation results when available, and carry a complete formatted report attachment when needed."
+
+* status MS
+  * ^short = "Diagnostic report status"
+  * ^definition = "The current status of the diagnostic report shared with the referral."
+
+* category MS
+  * ^short = "Diagnostic service category"
+  * ^definition = "The diagnostic service category, such as laboratory, radiology, or pathology."
+
+* code MS
+  * ^short = "Diagnostic report type"
+  * ^definition = "The diagnostic report or panel represented by this resource. The inherited FHIR R4 preferred binding uses LOINC diagnostic report codes."
+
+* subject 1..1 MS
+* subject only Reference(ERefPatient)
+  * ^short = "Patient who is the subject of the report"
+  * ^definition = "The eReferral patient whose diagnostic findings are summarized in this report."
+
+* effective[x] MS
+  * ^short = "Clinically relevant report time"
+  * ^definition = "The clinically relevant time or period for the diagnostic observations represented by the report."
+
+* issued MS
+  * ^short = "When the report was issued"
+  * ^definition = "The date and time when the diagnostic report was released."
+
+* performer MS
+* performer only Reference(PHCorePractitioner or PHCoreOrganization)
+  * ^short = "Diagnostic report performer"
+  * ^definition = "The practitioner, laboratory, imaging center, or other healthcare organization responsible for the report."
+
+* result MS
+* result only Reference(ERefObservation)
+  * ^short = "Structured atomic diagnostic results"
+  * ^definition = "References to structured atomic Observation results included in or summarized by this report."
+
+* media MS
+
+* media.link MS
+  * ^short = "Selected key image"
+  * ^definition = "A reference to a Media resource containing a selected key image associated with the report. The complete issued report belongs in presentedForm."
+
+* conclusion MS
+  * ^short = "Clinical conclusion or interpretation"
+  * ^definition = "A concise clinical interpretation or summary of the diagnostic findings."
+
+* presentedForm MS
+  * ^short = "Complete formatted diagnostic report"
+  * ^definition = "The complete report as an attachment. Supported formats are PDF or PDF/A (application/pdf), PNG (image/png), JPG/JPEG (image/jpeg), and GIF (image/gif). Attachments should not exceed 5 MB (5,242,880 bytes)."
+
+* presentedForm.contentType 1..1
+
+* obeys eref-diagnosticreport-attachment-size
+
+Invariant: eref-diagnosticreport-attachment-size
+Description: "Presented report attachments should not exceed 5 MB when Attachment.size is populated."
+Severity: #warning
+Expression: "presentedForm.all(size.empty() or size <= 5242880)"

--- a/input/fsh/profiles/ERefDiagnosticReport.fsh
+++ b/input/fsh/profiles/ERefDiagnosticReport.fsh
@@ -24,6 +24,12 @@ Description: "Diagnostic report profile for laboratory, diagnostic imaging, path
   * ^short = "Diagnostic report type"
   * ^definition = "The diagnostic report or panel represented by this resource. The inherited FHIR R4 preferred binding uses LOINC diagnostic report codes."
 
+* basedOn MS
+* basedOn insert ObligationOptional
+* basedOn only Reference(ERefServiceRequest)
+  * ^short = "Referral request associated with this report"
+  * ^definition = "The Philippine eReferral ServiceRequest associated with this diagnostic report, when known."
+
 * subject 1..1 MS
 * subject only Reference(ERefPatient)
   * ^short = "Patient who is the subject of the report"
@@ -58,6 +64,7 @@ Description: "Diagnostic report profile for laboratory, diagnostic imaging, path
   * ^definition = "A concise clinical interpretation or summary of the diagnostic findings."
 
 * presentedForm MS
+* presentedForm insert ObligationOptional
   * ^short = "Complete formatted diagnostic report"
   * ^definition = "The complete report as an attachment. Supported formats are PDF or PDF/A (application/pdf), PNG (image/png), JPG/JPEG (image/jpeg), and GIF (image/gif). Attachments should not exceed 5 MB (5,242,880 bytes)."
 

--- a/input/fsh/profiles/ERefDiagnosticReport.fsh
+++ b/input/fsh/profiles/ERefDiagnosticReport.fsh
@@ -12,56 +12,20 @@ Description: "Diagnostic report profile for laboratory, diagnostic imaging, path
 * ^experimental = true
 * ^purpose = "To support referral handover of diagnostic reports that summarize or group diagnostic findings, link to structured atomic Observation results when available, and carry a complete formatted report attachment when needed."
 
-* status MS
-  * ^short = "Diagnostic report status"
-  * ^definition = "The current status of the diagnostic report shared with the referral."
-
-* category MS
-  * ^short = "Diagnostic service category"
-  * ^definition = "The diagnostic service category, such as laboratory, radiology, or pathology."
-
-* code MS
-  * ^short = "Diagnostic report type"
-  * ^definition = "The diagnostic report or panel represented by this resource. The inherited FHIR R4 preferred binding uses LOINC diagnostic report codes."
-
 * basedOn MS
 * basedOn insert ObligationOptional
 * basedOn only Reference(ERefServiceRequest)
-  * ^short = "Referral request associated with this report"
-  * ^definition = "The Philippine eReferral ServiceRequest associated with this diagnostic report, when known."
 
-* subject 1..1 MS
+* subject MS
+* subject insert ObligationOptional
+
 * subject only Reference(ERefPatient)
-  * ^short = "Patient who is the subject of the report"
-  * ^definition = "The eReferral patient whose diagnostic findings are summarized in this report."
 
-* effective[x] MS
-  * ^short = "Clinically relevant report time"
-  * ^definition = "The clinically relevant time or period for the diagnostic observations represented by the report."
 
-* issued MS
-  * ^short = "When the report was issued"
-  * ^definition = "The date and time when the diagnostic report was released."
 
-* performer MS
 * performer only Reference(PHCorePractitioner or PHCoreOrganization)
-  * ^short = "Diagnostic report performer"
-  * ^definition = "The practitioner, laboratory, imaging center, or other healthcare organization responsible for the report."
 
-* result MS
 * result only Reference(ERefObservation)
-  * ^short = "Structured atomic diagnostic results"
-  * ^definition = "References to structured atomic Observation results included in or summarized by this report."
-
-* media MS
-
-* media.link MS
-  * ^short = "Selected key image"
-  * ^definition = "A reference to a Media resource containing a selected key image associated with the report. The complete issued report belongs in presentedForm."
-
-* conclusion MS
-  * ^short = "Clinical conclusion or interpretation"
-  * ^definition = "A concise clinical interpretation or summary of the diagnostic findings."
 
 * presentedForm MS
 * presentedForm insert ObligationOptional

--- a/input/fsh/profiles/ERefServiceRequest.fsh
+++ b/input/fsh/profiles/ERefServiceRequest.fsh
@@ -87,13 +87,14 @@ Description: "Profile for ServiceRequest resource in the Philippine eReferral co
 
 
 // TDG Row REF-15: "Time Called" and other supporting clinical information
-// Clinical Summary elements: Conditions, Observations, Procedures, Medications, Immunizations
+// Clinical Summary elements: Conditions, Observations, Procedures, Medications,
+// Immunizations, and DiagnosticReports
 * supportingInfo MS
 * insert ObligationOptional
 
-* supportingInfo only Reference(PHCoreCondition or PHCoreObservation or PHCoreProcedure or PHCoreMedicationAdministration or PHCoreImmunization)
+* supportingInfo only Reference(PHCoreCondition or PHCoreObservation or PHCoreProcedure or PHCoreMedicationAdministration or PHCoreImmunization or ERefDiagnosticReport)
   * ^short = "Additional clinical information"
-  * ^definition = "Additional clinical information relevant to the referral, such as relevant conditions, procedures, medications, immunizations, or observations."
+  * ^definition = "Additional clinical information relevant to the referral, such as relevant conditions, procedures, medications, immunizations, observations, or diagnostic reports."
 
 // TDG Row REF-16: "Reason for Referral (service type)" - Classification of requested service
 * code MS

--- a/input/pagecontent/StructureDefinition-ereferral-diagnostic-report-intro.md
+++ b/input/pagecontent/StructureDefinition-ereferral-diagnostic-report-intro.md
@@ -1,8 +1,8 @@
 ### EReferral DiagnosticReport
 
-The **EReferral DiagnosticReport** profile represents laboratory, diagnostic imaging, pathology, and histopathology reports that are relevant to referral handover. A report is normally linked from `ServiceRequest.supportingInfo`.
+The **EReferral DiagnosticReport** profile represents laboratory, diagnostic imaging, pathology, and histopathology reports that are relevant to referral handover. A report is normally linked from `ServiceRequest.supportingInfo`. When the originating referral request is known, `DiagnosticReport.basedOn` may reference the associated `ERefServiceRequest`.
 
-Use the official [FHIR R4 DiagnosticReport examples](https://hl7.org/fhir/R4/diagnosticreport-examples.html) as the base examples for DiagnosticReport payloads. PeReF does not add local DiagnosticReport example instances while PH Core has no DiagnosticReport profile or examples to extend.
+The [PeReF PDF attachment example](DiagnosticReport-ExampleERefDiagnosticReportPDF.html) demonstrates a report associated with an eReferral and a complete report attachment represented through `presentedForm`. Additional payload patterns are available in the official [FHIR R4 DiagnosticReport examples](https://hl7.org/fhir/R4/diagnosticreport-examples.html).
 
 #### Clinical Rationale
 
@@ -12,6 +12,7 @@ Referral recipients need both individual findings and the report-level interpret
 
 - Use `Observation` for an atomic finding or measurement, such as a glucose result.
 - Use `DiagnosticReport.result` to link the report to structured atomic `ERefObservation` results when available.
+- Use `DiagnosticReport.basedOn` to reference the associated `ERefServiceRequest` when known.
 - Use `DiagnosticReport.conclusion` for a concise report-level interpretation or summary.
 - Use `DiagnosticReport.presentedForm` for the complete formatted report.
 - Use `DiagnosticReport.media.link` only for selected key images represented as `Media`; it is not a substitute for the complete report attachment.

--- a/input/pagecontent/StructureDefinition-ereferral-diagnostic-report-intro.md
+++ b/input/pagecontent/StructureDefinition-ereferral-diagnostic-report-intro.md
@@ -1,0 +1,38 @@
+### EReferral DiagnosticReport
+
+The **EReferral DiagnosticReport** profile represents laboratory, diagnostic imaging, pathology, and histopathology reports that are relevant to referral handover. A report is normally linked from `ServiceRequest.supportingInfo`.
+
+Use the official [FHIR R4 DiagnosticReport examples](https://hl7.org/fhir/R4/diagnosticreport-examples.html) as the base examples for DiagnosticReport payloads. PeReF does not add local DiagnosticReport example instances while PH Core has no DiagnosticReport profile or examples to extend.
+
+#### Clinical Rationale
+
+Referral recipients need both individual findings and the report-level interpretation produced by a laboratory, imaging service, or pathologist. `Observation` alone represents atomic findings; `DiagnosticReport` supplies the report context, groups structured results, carries a conclusion, and can include the complete issued report.
+
+#### Diagnostic Results
+
+- Use `Observation` for an atomic finding or measurement, such as a glucose result.
+- Use `DiagnosticReport.result` to link the report to structured atomic `ERefObservation` results when available.
+- Use `DiagnosticReport.conclusion` for a concise report-level interpretation or summary.
+- Use `DiagnosticReport.presentedForm` for the complete formatted report.
+- Use `DiagnosticReport.media.link` only for selected key images represented as `Media`; it is not a substitute for the complete report attachment.
+
+`DiagnosticReport.code` retains the FHIR R4 preferred binding to diagnostic report codes from [LOINC](https://loinc.org/). PeReF does not introduce a narrower report-code value set for v0.1.
+
+This profile does not define a full laboratory information system, radiology workflow, PACS integration, DICOM exchange, or `ImagingStudy` workflow.
+
+#### Report Attachments
+
+Complete report attachments use `presentedForm`. Supported MIME types are:
+
+| File type | MIME type |
+|-----------|-----------|
+| PDF or PDF/A | `application/pdf` |
+| PNG | `image/png` |
+| JPG or JPEG | `image/jpeg` |
+| GIF | `image/gif` |
+
+Attachments should not exceed **5 MB (5,242,880 bytes)**. The profile applies this as a warning when `Attachment.size` is populated. Implementers should prefer `Attachment.url` for externally retrievable report content or use a small payload when inline `Attachment.data` is necessary; large base64 examples are intentionally excluded.
+
+The supported MIME types remain narrative guidance for v0.1. `Attachment.contentType` keeps its standard FHIR R4 required binding to the MIME Types value set; PeReF does not add a custom MIME CodeSystem or ValueSet.
+
+This is a simple eReferral attachment approach aligned with [FHIR R4 DiagnosticReport](https://hl7.org/fhir/R4/diagnosticreport.html) and informed by [NHS e-Referral file attachment guidance](https://digital.nhs.uk/services/e-referral-service/api/updates-and-releases/roadmap/file-attachments), adapted for PeReF referral supporting information.

--- a/input/pagecontent/StructureDefinition-ereferral-diagnostic-report-intro.md
+++ b/input/pagecontent/StructureDefinition-ereferral-diagnostic-report-intro.md
@@ -1,25 +1,10 @@
 ### EReferral DiagnosticReport
 
-The **EReferral DiagnosticReport** profile represents laboratory, diagnostic imaging, pathology, and histopathology reports that are relevant to referral handover. A report is normally linked from `ServiceRequest.supportingInfo`. When the originating referral request is known, `DiagnosticReport.basedOn` may reference the associated `ERefServiceRequest`.
+The **EReferral DiagnosticReport** profile represents diagnostic reports shared as supporting clinical information in a Philippine eReferral. Reports are linked from `ServiceRequest.supportingInfo`.
 
-The [PeReF PDF attachment example](DiagnosticReport-ExampleERefDiagnosticReportPDF.html) demonstrates a report associated with an eReferral and a complete report attachment represented through `presentedForm`. Additional payload patterns are available in the official [FHIR R4 DiagnosticReport examples](https://hl7.org/fhir/R4/diagnosticreport-examples.html).
+The minimum requirement is `DiagnosticReport.presentedForm` with an `Attachment` carrying the complete report content. `presentedForm.contentType` is required when `presentedForm` is populated.
 
-#### Clinical Rationale
-
-Referral recipients need both individual findings and the report-level interpretation produced by a laboratory, imaging service, or pathologist. `Observation` alone represents atomic findings; `DiagnosticReport` supplies the report context, groups structured results, carries a conclusion, and can include the complete issued report.
-
-#### Diagnostic Results
-
-- Use `Observation` for an atomic finding or measurement, such as a glucose result.
-- Use `DiagnosticReport.result` to link the report to structured atomic `ERefObservation` results when available.
-- Use `DiagnosticReport.basedOn` to reference the associated `ERefServiceRequest` when known.
-- Use `DiagnosticReport.conclusion` for a concise report-level interpretation or summary.
-- Use `DiagnosticReport.presentedForm` for the complete formatted report.
-- Use `DiagnosticReport.media.link` only for selected key images represented as `Media`; it is not a substitute for the complete report attachment.
-
-`DiagnosticReport.code` retains the FHIR R4 preferred binding to diagnostic report codes from [LOINC](https://loinc.org/). PeReF does not introduce a narrower report-code value set for v0.1.
-
-This profile does not define a full laboratory information system, radiology workflow, PACS integration, DICOM exchange, or `ImagingStudy` workflow.
+Complete attachments can be added through `presentedForm`.
 
 #### Report Attachments
 

--- a/input/pagecontent/StructureDefinition-ereferral-service-request-intro.md
+++ b/input/pagecontent/StructureDefinition-ereferral-service-request-intro.md
@@ -112,12 +112,14 @@ Allowed resource types:
 - **Procedure** - Previous procedures relevant to referral
 - **MedicationAdministration** - Current medications
 - **Immunization** - Vaccination history
+- **DiagnosticReport** - Laboratory, imaging, pathology, or other diagnostic reports, including complete report attachments
 
 **Example:**
 ```fsh
 * supportingInfo[0] = Reference(Observation/BP-001)
 * supportingInfo[+] = Reference(Observation/ECG-001)
 * supportingInfo[+] = Reference(Condition/Diabetes-001)
+* supportingInfo[+] = Reference(DiagnosticReport/LabReport-001)
 ```
 
 ---
@@ -229,6 +231,7 @@ The EReferral ServiceRequest typically works with:
 | [Organization](http://hl7.org/fhir/R4/organization.html) | `performer` | Receiving facility |
 | [Condition](http://hl7.org/fhir/R4/condition.html) | `reasonReference`, `supportingInfo` | Clinical diagnoses |
 | [Observation](http://hl7.org/fhir/R4/observation.html) | `supportingInfo` | Vital signs, lab results |
+| [DiagnosticReport](StructureDefinition-ereferral-diagnostic-report.html) | `supportingInfo` | Diagnostic report summaries, structured results, and formatted report attachments |
 | [Task](http://hl7.org/fhir/R4/task.html) | `Task.focus` | Workflow tracking and receiving-facility response |
 | [Provenance](http://hl7.org/fhir/R4/provenance.html) | `relevantHistory` | Audit trail and signatures |
 | [Encounter](http://hl7.org/fhir/R4/encounter.html) | Context | Often linked via Encounter context |

--- a/input/pagecontent/coverage-map.md
+++ b/input/pagecontent/coverage-map.md
@@ -24,6 +24,7 @@ This page maps the v0.1 minimum referral workflow to the IG artifacts used by th
 | EReferral Provenance | Audit and signature support | [StructureDefinition-ereferral-provenance.html](StructureDefinition-ereferral-provenance.html) |
 | EReferral MedicationAdministration | Optional clinical summary support | [StructureDefinition-ereferral-medication-administration.html](StructureDefinition-ereferral-medication-administration.html) |
 | ERefImmunization | Optional clinical summary support | [StructureDefinition-ereferral-immunization.html](StructureDefinition-ereferral-immunization.html) |
+| EReferral DiagnosticReport | Optional diagnostic report and attachment support | [StructureDefinition-ereferral-diagnostic-report.html](StructureDefinition-ereferral-diagnostic-report.html) |
 
 ## Example Coverage
 


### PR DESCRIPTION
## Summary
Adds the `ERefDiagnosticReport` profile for laboratory, diagnostic imaging, pathology, and histopathology reports used as referral supporting information.

## Related Issue
Closes #110

## Type of Work
- [ ] CI/Build Infrastructure
- [ ] ConceptMap
- [x] Example
- [x] Narrative Page
- [ ] PH-Core Dependency Change
- [x] Profile
- [ ] Test Script
- [ ] ValueSet
- [ ] Extension
- [ ] CodeSystem
- [x] Documentation
- [ ] Other

## Changes Made
- Added `ERefDiagnosticReport`, derived from the FHIR R4 `DiagnosticReport` resource because PH Core does not currently publish a DiagnosticReport profile.
- Added optional `DiagnosticReport.basedOn` support for referencing the associated `ERefServiceRequest`, with the project's optional obligation.
- Constrained the report subject to `ERefPatient`, performers to the existing PH Core practitioner or organization profiles, and structured results to `ERefObservation`.
- Marked the referral handover elements as Must Support, including report status, category, code, effective time, issued time, performer, results, media, conclusion, and `presentedForm`.
- Applied the project's optional obligation to `presentedForm`.
- Added a warning invariant limiting populated `presentedForm.size` values to 5 MB (5,242,880 bytes).
- Documented PDF/PDF-A, PNG, JPEG, and GIF attachment guidance and the distinction between atomic `Observation` findings, report-level `DiagnosticReport` content, selected `media.link` images, and complete `presentedForm` attachments.
- Added `ExampleERefDiagnosticReportPDF`, a laboratory report example using LOINC `11502-2` that exercises `presentedForm` with PDF attachment metadata and references an `ERefServiceRequest`.
- Added `ERefDiagnosticReport` to the allowed `ServiceRequest.supportingInfo` references.
- Updated the ServiceRequest narrative and IG coverage map.

## Validation / Testing
- [x] IG builds successfully
- [x] Examples validate
- [x] Terminology checked
- [x] Links verified
- [x] Other: SUSHI 3.19.0 completed with 0 errors and 0 warnings.
- [x] Other: Local IG Publisher completed successfully with 0 broken links.
- [x] Other: Upstream branch-name, SUSHI, and IG Publisher checks passed.

The included PDF attachment example has zero validation errors and zero warnings in the local Publisher build. Its only offline-build message is informational because `application/pdf` cannot be terminology-validated without a terminology server.

## Reviewer Notes
Please review:

- Whether `presentedForm` should remain Must Support for v0.1.
- Whether selected images should use `media.link` now or initially be handled through `presentedForm`.
- Whether DiagnosticReport should remain limited to `ServiceRequest.supportingInfo`.
- Whether LOINC `11502-2` ("Laboratory report") is appropriate for the included beta example.
- Whether attachment size and file-type rules should remain warning/narrative guidance or become stricter validation constraints.

## Preview / Screenshots
- [Published branch build](https://build.fhir.org/ig/jldalisay95/ph-ereferral-jld/branches/issue-110-EReferralDiagnosticReport/)
- [Rendered PDF attachment example](https://build.fhir.org/ig/jldalisay95/ph-ereferral-jld/branches/issue-110-EReferralDiagnosticReport/DiagnosticReport-ExampleERefDiagnosticReportPDF.html)
