### PR TITLE
docs: Update index.md to include contributors section

### DIFF
--- a/input/pagecontent/index.md
+++ b/input/pagecontent/index.md
@@ -126,7 +126,7 @@ The following individuals contributed to the development of the Philippine eRefe
 - Felipe Canlas
 - Noel del Castillo
 - Lester Batay-an
-- Arturo Ongkeko
+- Dir. Arturo Ongkeko
 - Dr. Thomas Niccolo Reyes
 - Dr. Sofia Lemuelle Capistrano
 - Jan Michael Herber

--- a/input/pagecontent/index.md
+++ b/input/pagecontent/index.md
@@ -110,6 +110,31 @@ PH Core provides the **parent/base profiles** used by this IG. PH eReferral:
 
 This layered approach enables reuse of common PH Core definitions while addressing the specific needs of HCPN referral workflows mandated by the [UHC Act](https://elibrary.judiciary.gov.ph/thebookshelf/showdocs/2/86448).
 
+## Contributors
+
+The following individuals contributed to the development of the Philippine eReferral Implementation Guide:
+
+- John Lemuel Dalisay, IG Lead
+- Dethalee Gabrielle Velasquez, PMO
+- Dr. Alvin Marcelo
+- Dr. Jaime Kristoffer Punzalan
+- Dr. Paolo Miguel Baquiano
+- Dr. Reina Juno Sumatra
+- Umer Nisar
+- John Carter
+- Jörn Guy Süß
+- Felipe Canlas
+- Noel del Castillo
+- Lester Batay-an
+- Arturo Ongkeko
+- Dr. Thomas Niccolo Reyes
+- Dr. Sofia Lemuelle Capistrano
+- Jan Michael Herber
+- Gerard Paolo Villanueva, IG Authoring Lead
+- Errol Buenaventura, TDG Lead
+- Lawrence Macalalad, CDG Lead
+- Jaylord Ambal
+
 ## Dependencies
 
 {% include ip-statements.xhtml %}

--- a/input/pagecontent/index.md
+++ b/input/pagecontent/index.md
@@ -114,8 +114,8 @@ This layered approach enables reuse of common PH Core definitions while addressi
 
 The following individuals contributed to the development of the Philippine eReferral Implementation Guide:
 
-- John Lemuel Dalisay, IG Lead
-- Dethalee Gabrielle Velasquez, PMO
+- John Lemuel Dalisay
+- Dethalee Gabrielle Velasquez
 - Dr. Alvin Marcelo
 - Dr. Jaime Kristoffer Punzalan
 - Dr. Paolo Miguel Baquiano
@@ -130,9 +130,9 @@ The following individuals contributed to the development of the Philippine eRefe
 - Dr. Thomas Niccolo Reyes
 - Dr. Sofia Lemuelle Capistrano
 - Jan Michael Herber
-- Gerard Paolo Villanueva, IG Authoring Lead
-- Errol Buenaventura, TDG Lead
-- Lawrence Macalalad, CDG Lead
+- Gerard Paolo Villanueva
+- Errol Buenaventura
+- Lawrence Macalalad
 - Jaylord Ambal
 
 ## Dependencies


### PR DESCRIPTION
## Summary
Adds a Contributors section to the home page acknowledging the individuals who contributed to the development of the Philippine eReferral Implementation Guide.

## Related Issue
Closes #40

## Type of Work
- [ ] CI/Build Infrastructure
- [ ] ConceptMap
- [ ] Example
- [ ] Narrative Page
- [ ] PH-Core Dependency Change
- [ ] Profile
- [ ] Test Script
- [ ] ValueSet
- [ ] Extension
- [ ] CodeSystem
- [x] Documentation
- [ ] Other

## Changes Made
- Added a new "## Contributors" section to `input/pagecontent/index.md` positioned after the "Relationship with Other IGs" section and before "## Dependencies"

## Validation / Testing
- [x] IG builds successfully
- [ ] Examples validate
- [ ] Terminology checked
- [ ] Links verified
- [ ] Other:

## Reviewer Notes
Review the completeness and accuracy of the contributor list, particularly the roles and titles assigned.

## Preview / Screenshots
https://build.fhir.org/ig/eabuenaventura/eab-ph-ereferral/branches/40-include-contributors