### PR TITLE
[Profile] Add CapabilityStatement post-Connectathon (#147)

### DIFF
--- a/input/fsh/aliases.fsh
+++ b/input/fsh/aliases.fsh
@@ -30,6 +30,9 @@ Alias: $signature-type = urn:iso-astm:E1762-95:2013
 // RESTful security service codes
 Alias: $restful-security-service = http://terminology.hl7.org/CodeSystem/restful-security-service
 
+// CapabilityStatement expectation extension (AU Core / AU eReq pattern)
+Alias: $cs-expectation = http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation
+
 // Obligation extension
 Alias: $obligation = http://hl7.org/fhir/StructureDefinition/obligation
 

--- a/input/fsh/aliases.fsh
+++ b/input/fsh/aliases.fsh
@@ -27,6 +27,9 @@ Alias: $v3-DataOperation = http://terminology.hl7.org/CodeSystem/v3-DataOperatio
 Alias: $provenance-participant-type = http://terminology.hl7.org/CodeSystem/provenance-participant-type
 Alias: $signature-type = urn:iso-astm:E1762-95:2013
 
+// RESTful security service codes
+Alias: $restful-security-service = http://terminology.hl7.org/CodeSystem/restful-security-service
+
 // Obligation extension
 Alias: $obligation = http://hl7.org/fhir/StructureDefinition/obligation
 

--- a/input/fsh/examples/ERefCapabilityStatementExample.fsh
+++ b/input/fsh/examples/ERefCapabilityStatementExample.fsh
@@ -4,6 +4,8 @@ Usage: #definition
 Title: "PH eReferral Server CapabilityStatement"
 Description: "CapabilityStatement for the PH eReferral Implementation Guide. Defines the conformance requirements for FHIR servers implementing the eReferral workflow. Validated at the June 2026 Aklan Connectathon with the Ana Reyes referral scenario (Kalibo Health Center -> Dr. Rafael S. Tumbokon Memorial Hospital)."
 
+* implementationGuide[0] = "https://fhir.doh.gov.ph/phcore/ImplementationGuide/fhir.ph.core"
+
 * name = "PHeReferralServerCapabilityStatement"
 * version = "0.1.0"
 * status = #draft
@@ -25,24 +27,40 @@ Description: "CapabilityStatement for the PH eReferral Implementation Guide. Def
 * rest[server].security.service = $restful-security-service#SMART-on-FHIR "SMART-on-FHIR"
 * rest[server].security.description = "Implementations SHOULD use SMART on FHIR or equivalent bearer-token authentication. Transport security (TLS) is REQUIRED. See the PH Core IG security section for base requirements."
 
-* rest[server].interaction[+].code = #transaction
+* rest[server].interaction[+].extension[$cs-expectation].url = "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation"
+* rest[server].interaction[=].extension[$cs-expectation].valueCode = #SHALL
+* rest[server].interaction[=].code = #transaction
 * rest[server].interaction[=].documentation = "Transaction Bundle support for atomic submission of referral packages. The Ana Reyes example uses POST for clinical resources and conditional PUT for master data within a single transaction Bundle."
+
+* rest[server].interaction[+].extension[$cs-expectation].url = "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation"
+* rest[server].interaction[=].extension[$cs-expectation].valueCode = #MAY
+* rest[server].interaction[=].code = #batch
 
 // =================================================================================
 // Resource: Patient
 // =================================================================================
-* rest[server].resource[+].type = #Patient
+* rest[server].resource[+].extension[$cs-expectation].url = "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation"
+* rest[server].resource[=].extension[$cs-expectation].valueCode = #SHALL
+* rest[server].resource[=].type = #Patient
 * rest[server].resource[=].profile = "https://fhir.doh.gov.ph/pheref/StructureDefinition/ereferral-patient"
 * rest[server].resource[=].documentation = "Patient demographics and identifiers for referral subjects. Uses PhilSys ID for conditional update matching. Must Support: name, gender, birthDate, telecom, address (PSGC), contact/next of kin."
-* rest[server].resource[=].interaction[+].code = #read
-* rest[server].resource[=].interaction[+].code = #search-type
-* rest[server].resource[=].interaction[+].code = #create
-* rest[server].resource[=].interaction[+].code = #update
-* rest[server].resource[=].versioning = #no-version
-* rest[server].resource[=].readHistory = false
-* rest[server].resource[=].updateCreate = true
-* rest[server].resource[=].conditionalUpdate = true
-* rest[server].resource[=].conditionalDelete = #not-supported
+* rest[server].resource[=].interaction[+].extension[$cs-expectation].url = "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation"
+* rest[server].resource[=].interaction[=].extension[$cs-expectation].valueCode = #SHALL
+* rest[server].resource[=].interaction[=].code = #read
+* rest[server].resource[=].interaction[+].extension[$cs-expectation].url = "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation"
+* rest[server].resource[=].interaction[=].extension[$cs-expectation].valueCode = #SHALL
+* rest[server].resource[=].interaction[=].code = #search-type
+* rest[server].resource[=].interaction[+].extension[$cs-expectation].url = "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation"
+* rest[server].resource[=].interaction[=].extension[$cs-expectation].valueCode = #SHOULD
+* rest[server].resource[=].interaction[=].code = #create
+* rest[server].resource[=].interaction[+].extension[$cs-expectation].url = "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation"
+* rest[server].resource[=].interaction[=].extension[$cs-expectation].valueCode = #SHOULD
+* rest[server].resource[=].interaction[=].code = #update
+* rest[server].resource[=].searchInclude[+] = "Patient:identifier"
+* rest[server].resource[=].searchInclude[+] = "Patient:name"
+* rest[server].resource[=].searchParam[+].name = "_id"
+* rest[server].resource[=].searchParam[=].type = #token
+* rest[server].resource[=].searchParam[=].definition = "http://hl7.org/fhir/SearchParameter/Resource-id"
 * rest[server].resource[=].searchParam[+].name = "identifier"
 * rest[server].resource[=].searchParam[=].type = #token
 * rest[server].resource[=].searchParam[=].definition = "http://hl7.org/fhir/SearchParameter/Patient-identifier"
@@ -50,27 +68,34 @@ Description: "CapabilityStatement for the PH eReferral Implementation Guide. Def
 * rest[server].resource[=].searchParam[+].name = "name"
 * rest[server].resource[=].searchParam[=].type = #string
 * rest[server].resource[=].searchParam[=].definition = "http://hl7.org/fhir/SearchParameter/Patient-name"
-* rest[server].resource[=].searchParam[=].documentation = "Search by patient name."
 * rest[server].resource[=].searchParam[+].name = "birthdate"
 * rest[server].resource[=].searchParam[=].type = #date
 * rest[server].resource[=].searchParam[=].definition = "http://hl7.org/fhir/SearchParameter/individual-birthdate"
-* rest[server].resource[=].searchParam[=].documentation = "Search by patient birth date."
 
 // =================================================================================
 // Resource: Practitioner
 // =================================================================================
-* rest[server].resource[+].type = #Practitioner
+* rest[server].resource[+].extension[$cs-expectation].url = "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation"
+* rest[server].resource[=].extension[$cs-expectation].valueCode = #SHALL
+* rest[server].resource[=].type = #Practitioner
 * rest[server].resource[=].profile = "https://fhir.doh.gov.ph/phcore/StructureDefinition/ph-core-practitioner"
 * rest[server].resource[=].documentation = "Practitioner resource for referring and receiving clinicians. Uses PRC license number for conditional update matching."
-* rest[server].resource[=].interaction[+].code = #read
-* rest[server].resource[=].interaction[+].code = #search-type
-* rest[server].resource[=].interaction[+].code = #create
-* rest[server].resource[=].interaction[+].code = #update
-* rest[server].resource[=].versioning = #no-version
-* rest[server].resource[=].readHistory = false
-* rest[server].resource[=].updateCreate = true
-* rest[server].resource[=].conditionalUpdate = true
-* rest[server].resource[=].conditionalDelete = #not-supported
+* rest[server].resource[=].interaction[+].extension[$cs-expectation].url = "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation"
+* rest[server].resource[=].interaction[=].extension[$cs-expectation].valueCode = #SHALL
+* rest[server].resource[=].interaction[=].code = #read
+* rest[server].resource[=].interaction[+].extension[$cs-expectation].url = "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation"
+* rest[server].resource[=].interaction[=].extension[$cs-expectation].valueCode = #SHALL
+* rest[server].resource[=].interaction[=].code = #search-type
+* rest[server].resource[=].interaction[+].extension[$cs-expectation].url = "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation"
+* rest[server].resource[=].interaction[=].extension[$cs-expectation].valueCode = #SHOULD
+* rest[server].resource[=].interaction[=].code = #create
+* rest[server].resource[=].interaction[+].extension[$cs-expectation].url = "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation"
+* rest[server].resource[=].interaction[=].extension[$cs-expectation].valueCode = #SHOULD
+* rest[server].resource[=].interaction[=].code = #update
+* rest[server].resource[=].searchInclude[+] = "Practitioner:identifier"
+* rest[server].resource[=].searchParam[+].name = "_id"
+* rest[server].resource[=].searchParam[=].type = #token
+* rest[server].resource[=].searchParam[=].definition = "http://hl7.org/fhir/SearchParameter/Resource-id"
 * rest[server].resource[=].searchParam[+].name = "identifier"
 * rest[server].resource[=].searchParam[=].type = #token
 * rest[server].resource[=].searchParam[=].definition = "http://hl7.org/fhir/SearchParameter/Practitioner-identifier"
@@ -78,23 +103,31 @@ Description: "CapabilityStatement for the PH eReferral Implementation Guide. Def
 * rest[server].resource[=].searchParam[+].name = "name"
 * rest[server].resource[=].searchParam[=].type = #string
 * rest[server].resource[=].searchParam[=].definition = "http://hl7.org/fhir/SearchParameter/Practitioner-name"
-* rest[server].resource[=].searchParam[=].documentation = "Search by practitioner name."
 
 // =================================================================================
 // Resource: Organization
 // =================================================================================
-* rest[server].resource[+].type = #Organization
+* rest[server].resource[+].extension[$cs-expectation].url = "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation"
+* rest[server].resource[=].extension[$cs-expectation].valueCode = #SHALL
+* rest[server].resource[=].type = #Organization
 * rest[server].resource[=].profile = "https://fhir.doh.gov.ph/phcore/StructureDefinition/ph-core-organization"
 * rest[server].resource[=].documentation = "Organization resource for referring and receiving healthcare facilities. Uses NHFR facility code for conditional update. Includes HCPN network identifier and PSGC-coded address."
-* rest[server].resource[=].interaction[+].code = #read
-* rest[server].resource[=].interaction[+].code = #search-type
-* rest[server].resource[=].interaction[+].code = #create
-* rest[server].resource[=].interaction[+].code = #update
-* rest[server].resource[=].versioning = #no-version
-* rest[server].resource[=].readHistory = false
-* rest[server].resource[=].updateCreate = true
-* rest[server].resource[=].conditionalUpdate = true
-* rest[server].resource[=].conditionalDelete = #not-supported
+* rest[server].resource[=].interaction[+].extension[$cs-expectation].url = "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation"
+* rest[server].resource[=].interaction[=].extension[$cs-expectation].valueCode = #SHALL
+* rest[server].resource[=].interaction[=].code = #read
+* rest[server].resource[=].interaction[+].extension[$cs-expectation].url = "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation"
+* rest[server].resource[=].interaction[=].extension[$cs-expectation].valueCode = #SHALL
+* rest[server].resource[=].interaction[=].code = #search-type
+* rest[server].resource[=].interaction[+].extension[$cs-expectation].url = "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation"
+* rest[server].resource[=].interaction[=].extension[$cs-expectation].valueCode = #SHOULD
+* rest[server].resource[=].interaction[=].code = #create
+* rest[server].resource[=].interaction[+].extension[$cs-expectation].url = "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation"
+* rest[server].resource[=].interaction[=].extension[$cs-expectation].valueCode = #SHOULD
+* rest[server].resource[=].interaction[=].code = #update
+* rest[server].resource[=].searchInclude[+] = "Organization:identifier"
+* rest[server].resource[=].searchParam[+].name = "_id"
+* rest[server].resource[=].searchParam[=].type = #token
+* rest[server].resource[=].searchParam[=].definition = "http://hl7.org/fhir/SearchParameter/Resource-id"
 * rest[server].resource[=].searchParam[+].name = "identifier"
 * rest[server].resource[=].searchParam[=].type = #token
 * rest[server].resource[=].searchParam[=].definition = "http://hl7.org/fhir/SearchParameter/Organization-identifier"
@@ -102,23 +135,32 @@ Description: "CapabilityStatement for the PH eReferral Implementation Guide. Def
 * rest[server].resource[=].searchParam[+].name = "name"
 * rest[server].resource[=].searchParam[=].type = #string
 * rest[server].resource[=].searchParam[=].definition = "http://hl7.org/fhir/SearchParameter/Organization-name"
-* rest[server].resource[=].searchParam[=].documentation = "Search by organization name."
 
 // =================================================================================
 // Resource: PractitionerRole
 // =================================================================================
-* rest[server].resource[+].type = #PractitionerRole
+* rest[server].resource[+].extension[$cs-expectation].url = "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation"
+* rest[server].resource[=].extension[$cs-expectation].valueCode = #SHALL
+* rest[server].resource[=].type = #PractitionerRole
 * rest[server].resource[=].profile = "https://fhir.doh.gov.ph/pheref/StructureDefinition/ereferral-practitioner-role"
 * rest[server].resource[=].documentation = "PractitionerRole linking practitioners to facilities. Used for both sending context (referring practitioner) and receiving context (care navigator). Inherits PRC identifier from Practitioner for conditional update."
-* rest[server].resource[=].interaction[+].code = #read
-* rest[server].resource[=].interaction[+].code = #search-type
-* rest[server].resource[=].interaction[+].code = #create
-* rest[server].resource[=].interaction[+].code = #update
-* rest[server].resource[=].versioning = #no-version
-* rest[server].resource[=].readHistory = false
-* rest[server].resource[=].updateCreate = true
-* rest[server].resource[=].conditionalUpdate = true
-* rest[server].resource[=].conditionalDelete = #not-supported
+* rest[server].resource[=].interaction[+].extension[$cs-expectation].url = "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation"
+* rest[server].resource[=].interaction[=].extension[$cs-expectation].valueCode = #SHALL
+* rest[server].resource[=].interaction[=].code = #read
+* rest[server].resource[=].interaction[+].extension[$cs-expectation].url = "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation"
+* rest[server].resource[=].interaction[=].extension[$cs-expectation].valueCode = #SHALL
+* rest[server].resource[=].interaction[=].code = #search-type
+* rest[server].resource[=].interaction[+].extension[$cs-expectation].url = "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation"
+* rest[server].resource[=].interaction[=].extension[$cs-expectation].valueCode = #SHOULD
+* rest[server].resource[=].interaction[=].code = #create
+* rest[server].resource[=].interaction[+].extension[$cs-expectation].url = "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation"
+* rest[server].resource[=].interaction[=].extension[$cs-expectation].valueCode = #SHOULD
+* rest[server].resource[=].interaction[=].code = #update
+* rest[server].resource[=].searchInclude[+] = "PractitionerRole:practitioner"
+* rest[server].resource[=].searchInclude[+] = "PractitionerRole:organization"
+* rest[server].resource[=].searchParam[+].name = "_id"
+* rest[server].resource[=].searchParam[=].type = #token
+* rest[server].resource[=].searchParam[=].definition = "http://hl7.org/fhir/SearchParameter/Resource-id"
 * rest[server].resource[=].searchParam[+].name = "identifier"
 * rest[server].resource[=].searchParam[=].type = #token
 * rest[server].resource[=].searchParam[=].definition = "http://hl7.org/fhir/SearchParameter/PractitionerRole-identifier"
@@ -133,18 +175,29 @@ Description: "CapabilityStatement for the PH eReferral Implementation Guide. Def
 // =================================================================================
 // Resource: ServiceRequest
 // =================================================================================
-* rest[server].resource[+].type = #ServiceRequest
+* rest[server].resource[+].extension[$cs-expectation].url = "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation"
+* rest[server].resource[=].extension[$cs-expectation].valueCode = #SHALL
+* rest[server].resource[=].type = #ServiceRequest
 * rest[server].resource[=].profile = "https://fhir.doh.gov.ph/pheref/StructureDefinition/ereferral-service-request"
 * rest[server].resource[=].documentation = "Primary referral request resource. Central artifact linking patient, requester (via PractitionerRole), performer (receiving facility), reasonCode, reasonReference, and supportingInfo."
-* rest[server].resource[=].interaction[+].code = #read
-* rest[server].resource[=].interaction[+].code = #search-type
-* rest[server].resource[=].interaction[+].code = #create
-* rest[server].resource[=].versioning = #no-version
-* rest[server].resource[=].readHistory = false
-* rest[server].resource[=].updateCreate = false
-* rest[server].resource[=].conditionalCreate = false
-* rest[server].resource[=].conditionalUpdate = false
-* rest[server].resource[=].conditionalDelete = #not-supported
+* rest[server].resource[=].interaction[+].extension[$cs-expectation].url = "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation"
+* rest[server].resource[=].interaction[=].extension[$cs-expectation].valueCode = #SHALL
+* rest[server].resource[=].interaction[=].code = #read
+* rest[server].resource[=].interaction[+].extension[$cs-expectation].url = "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation"
+* rest[server].resource[=].interaction[=].extension[$cs-expectation].valueCode = #SHALL
+* rest[server].resource[=].interaction[=].code = #search-type
+* rest[server].resource[=].interaction[+].extension[$cs-expectation].url = "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation"
+* rest[server].resource[=].interaction[=].extension[$cs-expectation].valueCode = #SHOULD
+* rest[server].resource[=].interaction[=].code = #create
+* rest[server].resource[=].searchInclude[+] = "ServiceRequest:patient"
+* rest[server].resource[=].searchInclude[+] = "ServiceRequest:requester"
+* rest[server].resource[=].searchInclude[+] = "ServiceRequest:performer"
+* rest[server].resource[=].searchInclude[+] = "ServiceRequest:encounter"
+* rest[server].resource[=].searchInclude[+] = "ServiceRequest:supporting-info"
+* rest[server].resource[=].searchRevInclude[+] = "Task:focus"
+* rest[server].resource[=].searchParam[+].name = "_id"
+* rest[server].resource[=].searchParam[=].type = #token
+* rest[server].resource[=].searchParam[=].definition = "http://hl7.org/fhir/SearchParameter/Resource-id"
 * rest[server].resource[=].searchParam[+].name = "performer"
 * rest[server].resource[=].searchParam[=].type = #reference
 * rest[server].resource[=].searchParam[=].definition = "http://hl7.org/fhir/SearchParameter/ServiceRequest-performer"
@@ -152,32 +205,40 @@ Description: "CapabilityStatement for the PH eReferral Implementation Guide. Def
 * rest[server].resource[=].searchParam[+].name = "status"
 * rest[server].resource[=].searchParam[=].type = #token
 * rest[server].resource[=].searchParam[=].definition = "http://hl7.org/fhir/SearchParameter/ServiceRequest-status"
-* rest[server].resource[=].searchParam[=].documentation = "Search referrals by status."
 * rest[server].resource[=].searchParam[+].name = "subject"
 * rest[server].resource[=].searchParam[=].type = #reference
 * rest[server].resource[=].searchParam[=].definition = "http://hl7.org/fhir/SearchParameter/ServiceRequest-subject"
-* rest[server].resource[=].searchParam[=].documentation = "Search referrals by patient."
 * rest[server].resource[=].searchParam[+].name = "authored"
 * rest[server].resource[=].searchParam[=].type = #date
 * rest[server].resource[=].searchParam[=].definition = "http://hl7.org/fhir/SearchParameter/ServiceRequest-authored"
-* rest[server].resource[=].searchParam[=].documentation = "Search by referral authored date."
 
 // =================================================================================
 // Resource: Task
 // =================================================================================
-* rest[server].resource[+].type = #Task
+* rest[server].resource[+].extension[$cs-expectation].url = "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation"
+* rest[server].resource[=].extension[$cs-expectation].valueCode = #SHALL
+* rest[server].resource[=].type = #Task
 * rest[server].resource[=].profile = "https://fhir.doh.gov.ph/pheref/StructureDefinition/ereferral-task"
 * rest[server].resource[=].documentation = "Workflow tracking resource for referral state management. Tracks progression: requested -> received -> accepted/rejected/referred-onward -> completed. Focus references the ServiceRequest."
-* rest[server].resource[=].interaction[+].code = #read
-* rest[server].resource[=].interaction[+].code = #search-type
-* rest[server].resource[=].interaction[+].code = #create
-* rest[server].resource[=].interaction[+].code = #update
-* rest[server].resource[=].versioning = #no-version
-* rest[server].resource[=].readHistory = false
-* rest[server].resource[=].updateCreate = false
-* rest[server].resource[=].conditionalCreate = false
-* rest[server].resource[=].conditionalUpdate = false
-* rest[server].resource[=].conditionalDelete = #not-supported
+* rest[server].resource[=].interaction[+].extension[$cs-expectation].url = "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation"
+* rest[server].resource[=].interaction[=].extension[$cs-expectation].valueCode = #SHALL
+* rest[server].resource[=].interaction[=].code = #read
+* rest[server].resource[=].interaction[+].extension[$cs-expectation].url = "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation"
+* rest[server].resource[=].interaction[=].extension[$cs-expectation].valueCode = #SHALL
+* rest[server].resource[=].interaction[=].code = #search-type
+* rest[server].resource[=].interaction[+].extension[$cs-expectation].url = "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation"
+* rest[server].resource[=].interaction[=].extension[$cs-expectation].valueCode = #SHOULD
+* rest[server].resource[=].interaction[=].code = #create
+* rest[server].resource[=].interaction[+].extension[$cs-expectation].url = "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation"
+* rest[server].resource[=].interaction[=].extension[$cs-expectation].valueCode = #SHOULD
+* rest[server].resource[=].interaction[=].code = #update
+* rest[server].resource[=].searchInclude[+] = "Task:focus"
+* rest[server].resource[=].searchInclude[+] = "Task:owner"
+* rest[server].resource[=].searchInclude[+] = "Task:patient"
+* rest[server].resource[=].searchInclude[+] = "Task:requester"
+* rest[server].resource[=].searchParam[+].name = "_id"
+* rest[server].resource[=].searchParam[=].type = #token
+* rest[server].resource[=].searchParam[=].definition = "http://hl7.org/fhir/SearchParameter/Resource-id"
 * rest[server].resource[=].searchParam[+].name = "focus"
 * rest[server].resource[=].searchParam[=].type = #reference
 * rest[server].resource[=].searchParam[=].definition = "http://hl7.org/fhir/SearchParameter/Task-focus"
@@ -185,35 +246,39 @@ Description: "CapabilityStatement for the PH eReferral Implementation Guide. Def
 * rest[server].resource[=].searchParam[+].name = "status"
 * rest[server].resource[=].searchParam[=].type = #token
 * rest[server].resource[=].searchParam[=].definition = "http://hl7.org/fhir/SearchParameter/Task-status"
-* rest[server].resource[=].searchParam[=].documentation = "Search tasks by workflow status."
 * rest[server].resource[=].searchParam[+].name = "owner"
 * rest[server].resource[=].searchParam[=].type = #reference
 * rest[server].resource[=].searchParam[=].definition = "http://hl7.org/fhir/SearchParameter/Task-owner"
-* rest[server].resource[=].searchParam[=].documentation = "Search tasks by assigned owner (receiving facility or care navigator)."
 * rest[server].resource[=].searchParam[+].name = "requester"
 * rest[server].resource[=].searchParam[=].type = #reference
 * rest[server].resource[=].searchParam[=].definition = "http://hl7.org/fhir/SearchParameter/Task-requester"
-* rest[server].resource[=].searchParam[=].documentation = "Search tasks by the requester."
 * rest[server].resource[=].searchParam[+].name = "patient"
 * rest[server].resource[=].searchParam[=].type = #reference
 * rest[server].resource[=].searchParam[=].definition = "http://hl7.org/fhir/SearchParameter/Task-patient"
-* rest[server].resource[=].searchParam[=].documentation = "Search tasks by patient."
 
 // =================================================================================
 // Resource: Encounter
 // =================================================================================
-* rest[server].resource[+].type = #Encounter
+* rest[server].resource[+].extension[$cs-expectation].url = "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation"
+* rest[server].resource[=].extension[$cs-expectation].valueCode = #SHALL
+* rest[server].resource[=].type = #Encounter
 * rest[server].resource[=].profile = "https://fhir.doh.gov.ph/pheref/StructureDefinition/ereferral-encounter"
 * rest[server].resource[=].documentation = "Encounter documenting clinical visit context for referral activities. Used for both initiating encounter and receiving (closure) encounter. basedOn references the ServiceRequest."
-* rest[server].resource[=].interaction[+].code = #read
-* rest[server].resource[=].interaction[+].code = #search-type
-* rest[server].resource[=].interaction[+].code = #create
-* rest[server].resource[=].versioning = #no-version
-* rest[server].resource[=].readHistory = false
-* rest[server].resource[=].updateCreate = false
-* rest[server].resource[=].conditionalCreate = false
-* rest[server].resource[=].conditionalUpdate = false
-* rest[server].resource[=].conditionalDelete = #not-supported
+* rest[server].resource[=].interaction[+].extension[$cs-expectation].url = "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation"
+* rest[server].resource[=].interaction[=].extension[$cs-expectation].valueCode = #SHALL
+* rest[server].resource[=].interaction[=].code = #read
+* rest[server].resource[=].interaction[+].extension[$cs-expectation].url = "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation"
+* rest[server].resource[=].interaction[=].extension[$cs-expectation].valueCode = #SHALL
+* rest[server].resource[=].interaction[=].code = #search-type
+* rest[server].resource[=].interaction[+].extension[$cs-expectation].url = "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation"
+* rest[server].resource[=].interaction[=].extension[$cs-expectation].valueCode = #SHOULD
+* rest[server].resource[=].interaction[=].code = #create
+* rest[server].resource[=].searchRevInclude[+] = "ServiceRequest:encounter"
+* rest[server].resource[=].searchInclude[+] = "Encounter:subject"
+* rest[server].resource[=].searchInclude[+] = "Encounter:based-on"
+* rest[server].resource[=].searchParam[+].name = "_id"
+* rest[server].resource[=].searchParam[=].type = #token
+* rest[server].resource[=].searchParam[=].definition = "http://hl7.org/fhir/SearchParameter/Resource-id"
 * rest[server].resource[=].searchParam[+].name = "subject"
 * rest[server].resource[=].searchParam[=].type = #reference
 * rest[server].resource[=].searchParam[=].definition = "http://hl7.org/fhir/SearchParameter/Encounter-subject"
@@ -224,18 +289,25 @@ Description: "CapabilityStatement for the PH eReferral Implementation Guide. Def
 // =================================================================================
 // Resource: Condition
 // =================================================================================
-* rest[server].resource[+].type = #Condition
+* rest[server].resource[+].extension[$cs-expectation].url = "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation"
+* rest[server].resource[=].extension[$cs-expectation].valueCode = #SHOULD
+* rest[server].resource[=].type = #Condition
 * rest[server].resource[=].profile = "https://fhir.doh.gov.ph/pheref/StructureDefinition/ereferral-condition"
 * rest[server].resource[=].documentation = "Condition resource for diagnoses and problems. Used for chief complaint (problem-list-item) and working impression (encounter-diagnosis). Linked to encounter."
-* rest[server].resource[=].interaction[+].code = #read
-* rest[server].resource[=].interaction[+].code = #search-type
-* rest[server].resource[=].interaction[+].code = #create
-* rest[server].resource[=].versioning = #no-version
-* rest[server].resource[=].readHistory = false
-* rest[server].resource[=].updateCreate = false
-* rest[server].resource[=].conditionalCreate = false
-* rest[server].resource[=].conditionalUpdate = false
-* rest[server].resource[=].conditionalDelete = #not-supported
+* rest[server].resource[=].interaction[+].extension[$cs-expectation].url = "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation"
+* rest[server].resource[=].interaction[=].extension[$cs-expectation].valueCode = #SHALL
+* rest[server].resource[=].interaction[=].code = #read
+* rest[server].resource[=].interaction[+].extension[$cs-expectation].url = "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation"
+* rest[server].resource[=].interaction[=].extension[$cs-expectation].valueCode = #SHALL
+* rest[server].resource[=].interaction[=].code = #search-type
+* rest[server].resource[=].interaction[+].extension[$cs-expectation].url = "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation"
+* rest[server].resource[=].interaction[=].extension[$cs-expectation].valueCode = #SHOULD
+* rest[server].resource[=].interaction[=].code = #create
+* rest[server].resource[=].searchInclude[+] = "Condition:subject"
+* rest[server].resource[=].searchInclude[+] = "Condition:encounter"
+* rest[server].resource[=].searchParam[+].name = "_id"
+* rest[server].resource[=].searchParam[=].type = #token
+* rest[server].resource[=].searchParam[=].definition = "http://hl7.org/fhir/SearchParameter/Resource-id"
 * rest[server].resource[=].searchParam[+].name = "subject"
 * rest[server].resource[=].searchParam[=].type = #reference
 * rest[server].resource[=].searchParam[=].definition = "http://hl7.org/fhir/SearchParameter/Condition-subject"
@@ -246,18 +318,25 @@ Description: "CapabilityStatement for the PH eReferral Implementation Guide. Def
 // =================================================================================
 // Resource: Observation
 // =================================================================================
-* rest[server].resource[+].type = #Observation
+* rest[server].resource[+].extension[$cs-expectation].url = "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation"
+* rest[server].resource[=].extension[$cs-expectation].valueCode = #SHOULD
+* rest[server].resource[=].type = #Observation
 * rest[server].resource[=].profile = "https://fhir.doh.gov.ph/pheref/StructureDefinition/ereferral-observation"
 * rest[server].resource[=].documentation = "Clinical observation resource for vital signs, lab results, and clinical measurements. Supports BP, heart rate, respiratory rate, SpO2, temperature, weight."
-* rest[server].resource[=].interaction[+].code = #read
-* rest[server].resource[=].interaction[+].code = #search-type
-* rest[server].resource[=].interaction[+].code = #create
-* rest[server].resource[=].versioning = #no-version
-* rest[server].resource[=].readHistory = false
-* rest[server].resource[=].updateCreate = false
-* rest[server].resource[=].conditionalCreate = false
-* rest[server].resource[=].conditionalUpdate = false
-* rest[server].resource[=].conditionalDelete = #not-supported
+* rest[server].resource[=].interaction[+].extension[$cs-expectation].url = "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation"
+* rest[server].resource[=].interaction[=].extension[$cs-expectation].valueCode = #SHALL
+* rest[server].resource[=].interaction[=].code = #read
+* rest[server].resource[=].interaction[+].extension[$cs-expectation].url = "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation"
+* rest[server].resource[=].interaction[=].extension[$cs-expectation].valueCode = #SHALL
+* rest[server].resource[=].interaction[=].code = #search-type
+* rest[server].resource[=].interaction[+].extension[$cs-expectation].url = "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation"
+* rest[server].resource[=].interaction[=].extension[$cs-expectation].valueCode = #SHOULD
+* rest[server].resource[=].interaction[=].code = #create
+* rest[server].resource[=].searchInclude[+] = "Observation:subject"
+* rest[server].resource[=].searchInclude[+] = "Observation:encounter"
+* rest[server].resource[=].searchParam[+].name = "_id"
+* rest[server].resource[=].searchParam[=].type = #token
+* rest[server].resource[=].searchParam[=].definition = "http://hl7.org/fhir/SearchParameter/Resource-id"
 * rest[server].resource[=].searchParam[+].name = "subject"
 * rest[server].resource[=].searchParam[=].type = #reference
 * rest[server].resource[=].searchParam[=].definition = "http://hl7.org/fhir/SearchParameter/Observation-subject"
@@ -269,18 +348,23 @@ Description: "CapabilityStatement for the PH eReferral Implementation Guide. Def
 // =================================================================================
 // Resource: Provenance
 // =================================================================================
-* rest[server].resource[+].type = #Provenance
+* rest[server].resource[+].extension[$cs-expectation].url = "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation"
+* rest[server].resource[=].extension[$cs-expectation].valueCode = #SHOULD
+* rest[server].resource[=].type = #Provenance
 * rest[server].resource[=].profile = "https://fhir.doh.gov.ph/pheref/StructureDefinition/ereferral-provenance"
 * rest[server].resource[=].documentation = "Provenance resource for audit trail and signature attestation. Targets the ServiceRequest. Records author, timestamp, and professional signature."
-* rest[server].resource[=].interaction[+].code = #read
-* rest[server].resource[=].interaction[+].code = #search-type
-* rest[server].resource[=].interaction[+].code = #create
-* rest[server].resource[=].versioning = #no-version
-* rest[server].resource[=].readHistory = false
-* rest[server].resource[=].updateCreate = false
-* rest[server].resource[=].conditionalCreate = false
-* rest[server].resource[=].conditionalUpdate = false
-* rest[server].resource[=].conditionalDelete = #not-supported
+* rest[server].resource[=].interaction[+].extension[$cs-expectation].url = "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation"
+* rest[server].resource[=].interaction[=].extension[$cs-expectation].valueCode = #SHALL
+* rest[server].resource[=].interaction[=].code = #read
+* rest[server].resource[=].interaction[+].extension[$cs-expectation].url = "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation"
+* rest[server].resource[=].interaction[=].extension[$cs-expectation].valueCode = #SHALL
+* rest[server].resource[=].interaction[=].code = #search-type
+* rest[server].resource[=].interaction[+].extension[$cs-expectation].url = "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation"
+* rest[server].resource[=].interaction[=].extension[$cs-expectation].valueCode = #SHOULD
+* rest[server].resource[=].interaction[=].code = #create
+* rest[server].resource[=].searchParam[+].name = "_id"
+* rest[server].resource[=].searchParam[=].type = #token
+* rest[server].resource[=].searchParam[=].definition = "http://hl7.org/fhir/SearchParameter/Resource-id"
 * rest[server].resource[=].searchParam[+].name = "target"
 * rest[server].resource[=].searchParam[=].type = #reference
 * rest[server].resource[=].searchParam[=].definition = "http://hl7.org/fhir/SearchParameter/Provenance-target"
@@ -288,18 +372,23 @@ Description: "CapabilityStatement for the PH eReferral Implementation Guide. Def
 // =================================================================================
 // Resource: RelatedPerson
 // =================================================================================
-* rest[server].resource[+].type = #RelatedPerson
+* rest[server].resource[+].extension[$cs-expectation].url = "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation"
+* rest[server].resource[=].extension[$cs-expectation].valueCode = #MAY
+* rest[server].resource[=].type = #RelatedPerson
 * rest[server].resource[=].profile = "https://fhir.doh.gov.ph/pheref/StructureDefinition/ereferral-related-person"
 * rest[server].resource[=].documentation = "RelatedPerson for patient contacts, next of kin, guardians, and accompanying persons. Optional resource for separate contact details."
-* rest[server].resource[=].interaction[+].code = #read
-* rest[server].resource[=].interaction[+].code = #search-type
-* rest[server].resource[=].interaction[+].code = #create
-* rest[server].resource[=].versioning = #no-version
-* rest[server].resource[=].readHistory = false
-* rest[server].resource[=].updateCreate = false
-* rest[server].resource[=].conditionalCreate = false
-* rest[server].resource[=].conditionalUpdate = false
-* rest[server].resource[=].conditionalDelete = #not-supported
+* rest[server].resource[=].interaction[+].extension[$cs-expectation].url = "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation"
+* rest[server].resource[=].interaction[=].extension[$cs-expectation].valueCode = #SHALL
+* rest[server].resource[=].interaction[=].code = #read
+* rest[server].resource[=].interaction[+].extension[$cs-expectation].url = "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation"
+* rest[server].resource[=].interaction[=].extension[$cs-expectation].valueCode = #SHALL
+* rest[server].resource[=].interaction[=].code = #search-type
+* rest[server].resource[=].interaction[+].extension[$cs-expectation].url = "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation"
+* rest[server].resource[=].interaction[=].extension[$cs-expectation].valueCode = #MAY
+* rest[server].resource[=].interaction[=].code = #create
+* rest[server].resource[=].searchParam[+].name = "_id"
+* rest[server].resource[=].searchParam[=].type = #token
+* rest[server].resource[=].searchParam[=].definition = "http://hl7.org/fhir/SearchParameter/Resource-id"
 * rest[server].resource[=].searchParam[+].name = "patient"
 * rest[server].resource[=].searchParam[=].type = #reference
 * rest[server].resource[=].searchParam[=].definition = "http://hl7.org/fhir/SearchParameter/RelatedPerson-patient"
@@ -307,18 +396,23 @@ Description: "CapabilityStatement for the PH eReferral Implementation Guide. Def
 // =================================================================================
 // Resource: Procedure
 // =================================================================================
-* rest[server].resource[+].type = #Procedure
+* rest[server].resource[+].extension[$cs-expectation].url = "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation"
+* rest[server].resource[=].extension[$cs-expectation].valueCode = #MAY
+* rest[server].resource[=].type = #Procedure
 * rest[server].resource[=].profile = "https://fhir.doh.gov.ph/pheref/StructureDefinition/ereferral-procedure"
 * rest[server].resource[=].documentation = "Procedure resource for treatments and procedures before or during the referral. Linked to encounter."
-* rest[server].resource[=].interaction[+].code = #read
-* rest[server].resource[=].interaction[+].code = #search-type
-* rest[server].resource[=].interaction[+].code = #create
-* rest[server].resource[=].versioning = #no-version
-* rest[server].resource[=].readHistory = false
-* rest[server].resource[=].updateCreate = false
-* rest[server].resource[=].conditionalCreate = false
-* rest[server].resource[=].conditionalUpdate = false
-* rest[server].resource[=].conditionalDelete = #not-supported
+* rest[server].resource[=].interaction[+].extension[$cs-expectation].url = "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation"
+* rest[server].resource[=].interaction[=].extension[$cs-expectation].valueCode = #SHALL
+* rest[server].resource[=].interaction[=].code = #read
+* rest[server].resource[=].interaction[+].extension[$cs-expectation].url = "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation"
+* rest[server].resource[=].interaction[=].extension[$cs-expectation].valueCode = #SHALL
+* rest[server].resource[=].interaction[=].code = #search-type
+* rest[server].resource[=].interaction[+].extension[$cs-expectation].url = "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation"
+* rest[server].resource[=].interaction[=].extension[$cs-expectation].valueCode = #MAY
+* rest[server].resource[=].interaction[=].code = #create
+* rest[server].resource[=].searchParam[+].name = "_id"
+* rest[server].resource[=].searchParam[=].type = #token
+* rest[server].resource[=].searchParam[=].definition = "http://hl7.org/fhir/SearchParameter/Resource-id"
 * rest[server].resource[=].searchParam[+].name = "subject"
 * rest[server].resource[=].searchParam[=].type = #reference
 * rest[server].resource[=].searchParam[=].definition = "http://hl7.org/fhir/SearchParameter/Procedure-subject"
@@ -328,18 +422,23 @@ Description: "CapabilityStatement for the PH eReferral Implementation Guide. Def
 // =================================================================================
 // Resource: MedicationAdministration
 // =================================================================================
-* rest[server].resource[+].type = #MedicationAdministration
+* rest[server].resource[+].extension[$cs-expectation].url = "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation"
+* rest[server].resource[=].extension[$cs-expectation].valueCode = #MAY
+* rest[server].resource[=].type = #MedicationAdministration
 * rest[server].resource[=].profile = "https://fhir.doh.gov.ph/pheref/StructureDefinition/ereferral-medication-administration"
 * rest[server].resource[=].documentation = "MedicationAdministration for documenting medications administered. Linked to encounter for clinical context."
-* rest[server].resource[=].interaction[+].code = #read
-* rest[server].resource[=].interaction[+].code = #search-type
-* rest[server].resource[=].interaction[+].code = #create
-* rest[server].resource[=].versioning = #no-version
-* rest[server].resource[=].readHistory = false
-* rest[server].resource[=].updateCreate = false
-* rest[server].resource[=].conditionalCreate = false
-* rest[server].resource[=].conditionalUpdate = false
-* rest[server].resource[=].conditionalDelete = #not-supported
+* rest[server].resource[=].interaction[+].extension[$cs-expectation].url = "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation"
+* rest[server].resource[=].interaction[=].extension[$cs-expectation].valueCode = #SHALL
+* rest[server].resource[=].interaction[=].code = #read
+* rest[server].resource[=].interaction[+].extension[$cs-expectation].url = "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation"
+* rest[server].resource[=].interaction[=].extension[$cs-expectation].valueCode = #SHALL
+* rest[server].resource[=].interaction[=].code = #search-type
+* rest[server].resource[=].interaction[+].extension[$cs-expectation].url = "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation"
+* rest[server].resource[=].interaction[=].extension[$cs-expectation].valueCode = #MAY
+* rest[server].resource[=].interaction[=].code = #create
+* rest[server].resource[=].searchParam[+].name = "_id"
+* rest[server].resource[=].searchParam[=].type = #token
+* rest[server].resource[=].searchParam[=].definition = "http://hl7.org/fhir/SearchParameter/Resource-id"
 * rest[server].resource[=].searchParam[+].name = "subject"
 * rest[server].resource[=].searchParam[=].type = #reference
 * rest[server].resource[=].searchParam[=].definition = "http://hl7.org/fhir/SearchParameter/MedicationAdministration-subject"
@@ -350,18 +449,23 @@ Description: "CapabilityStatement for the PH eReferral Implementation Guide. Def
 // =================================================================================
 // Resource: Immunization
 // =================================================================================
-* rest[server].resource[+].type = #Immunization
+* rest[server].resource[+].extension[$cs-expectation].url = "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation"
+* rest[server].resource[=].extension[$cs-expectation].valueCode = #MAY
+* rest[server].resource[=].type = #Immunization
 * rest[server].resource[=].profile = "https://fhir.doh.gov.ph/pheref/StructureDefinition/ereferral-immunization"
 * rest[server].resource[=].documentation = "Immunization resource for vaccination history as clinical context in referrals."
-* rest[server].resource[=].interaction[+].code = #read
-* rest[server].resource[=].interaction[+].code = #search-type
-* rest[server].resource[=].interaction[+].code = #create
-* rest[server].resource[=].versioning = #no-version
-* rest[server].resource[=].readHistory = false
-* rest[server].resource[=].updateCreate = false
-* rest[server].resource[=].conditionalCreate = false
-* rest[server].resource[=].conditionalUpdate = false
-* rest[server].resource[=].conditionalDelete = #not-supported
+* rest[server].resource[=].interaction[+].extension[$cs-expectation].url = "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation"
+* rest[server].resource[=].interaction[=].extension[$cs-expectation].valueCode = #SHALL
+* rest[server].resource[=].interaction[=].code = #read
+* rest[server].resource[=].interaction[+].extension[$cs-expectation].url = "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation"
+* rest[server].resource[=].interaction[=].extension[$cs-expectation].valueCode = #SHALL
+* rest[server].resource[=].interaction[=].code = #search-type
+* rest[server].resource[=].interaction[+].extension[$cs-expectation].url = "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation"
+* rest[server].resource[=].interaction[=].extension[$cs-expectation].valueCode = #MAY
+* rest[server].resource[=].interaction[=].code = #create
+* rest[server].resource[=].searchParam[+].name = "_id"
+* rest[server].resource[=].searchParam[=].type = #token
+* rest[server].resource[=].searchParam[=].definition = "http://hl7.org/fhir/SearchParameter/Resource-id"
 * rest[server].resource[=].searchParam[+].name = "patient"
 * rest[server].resource[=].searchParam[=].type = #reference
 * rest[server].resource[=].searchParam[+].name = "vaccine-code"
@@ -371,18 +475,23 @@ Description: "CapabilityStatement for the PH eReferral Implementation Guide. Def
 // =================================================================================
 // Resource: DiagnosticReport
 // =================================================================================
-* rest[server].resource[+].type = #DiagnosticReport
+* rest[server].resource[+].extension[$cs-expectation].url = "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation"
+* rest[server].resource[=].extension[$cs-expectation].valueCode = #MAY
+* rest[server].resource[=].type = #DiagnosticReport
 * rest[server].resource[=].profile = "http://hl7.org/fhir/StructureDefinition/DiagnosticReport"
 * rest[server].resource[=].documentation = "DiagnosticReport for laboratory results and diagnostic studies. Currently uses base FHIR profile."
-* rest[server].resource[=].interaction[+].code = #read
-* rest[server].resource[=].interaction[+].code = #search-type
-* rest[server].resource[=].interaction[+].code = #create
-* rest[server].resource[=].versioning = #no-version
-* rest[server].resource[=].readHistory = false
-* rest[server].resource[=].updateCreate = false
-* rest[server].resource[=].conditionalCreate = false
-* rest[server].resource[=].conditionalUpdate = false
-* rest[server].resource[=].conditionalDelete = #not-supported
+* rest[server].resource[=].interaction[+].extension[$cs-expectation].url = "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation"
+* rest[server].resource[=].interaction[=].extension[$cs-expectation].valueCode = #SHALL
+* rest[server].resource[=].interaction[=].code = #read
+* rest[server].resource[=].interaction[+].extension[$cs-expectation].url = "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation"
+* rest[server].resource[=].interaction[=].extension[$cs-expectation].valueCode = #SHALL
+* rest[server].resource[=].interaction[=].code = #search-type
+* rest[server].resource[=].interaction[+].extension[$cs-expectation].url = "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation"
+* rest[server].resource[=].interaction[=].extension[$cs-expectation].valueCode = #MAY
+* rest[server].resource[=].interaction[=].code = #create
+* rest[server].resource[=].searchParam[+].name = "_id"
+* rest[server].resource[=].searchParam[=].type = #token
+* rest[server].resource[=].searchParam[=].definition = "http://hl7.org/fhir/SearchParameter/Resource-id"
 * rest[server].resource[=].searchParam[+].name = "subject"
 * rest[server].resource[=].searchParam[=].type = #reference
 * rest[server].resource[=].searchParam[=].definition = "http://hl7.org/fhir/SearchParameter/DiagnosticReport-subject"

--- a/input/fsh/examples/ERefCapabilityStatementExample.fsh
+++ b/input/fsh/examples/ERefCapabilityStatementExample.fsh
@@ -1,0 +1,390 @@
+Instance: ExampleERefCapabilityStatement
+InstanceOf: ERefCapabilityStatement
+Usage: #definition
+Title: "PH eReferral Server CapabilityStatement"
+Description: "CapabilityStatement for the PH eReferral Implementation Guide. Defines the conformance requirements for FHIR servers implementing the eReferral workflow. Validated at the June 2026 Aklan Connectathon with the Ana Reyes referral scenario (Kalibo Health Center -> Dr. Rafael S. Tumbokon Memorial Hospital)."
+
+* name = "PHeReferralServerCapabilityStatement"
+* version = "0.1.0"
+* status = #draft
+* experimental = true
+* date = "2026-06-22"
+* publisher = "SILab CoP IG Accelerator (eReferral)"
+* description = "CapabilityStatement for the PH eReferral Implementation Guide. Defines the conformance requirements for FHIR servers implementing the eReferral workflow. Validated at the June 2026 Aklan Connectathon with the Ana Reyes referral scenario (Kalibo Health Center -> Dr. Rafael S. Tumbokon Memorial Hospital)."
+* kind = #requirements
+* fhirVersion = #4.0.1
+* format[0] = #json
+* format[+] = #xml
+
+// =================================================================================
+// REST Server Section
+// =================================================================================
+* rest[server].mode = #server
+* rest[server].documentation = "FHIR RESTful server supporting the PH eReferral workflow lifecycle: create referral -> send -> receive -> respond -> close. Transaction Bundles are supported for atomic submission of referral packages. Conditional updates are used for master data (Patient, Practitioner, Organization, PractitionerRole) to enable idempotent upsert semantics. POST is used for clinical/business data (ServiceRequest, Task, Encounter, Condition, Observation, Procedure, Provenance)."
+
+* rest[server].security.service = $restful-security-service#SMART-on-FHIR "SMART-on-FHIR"
+* rest[server].security.description = "Implementations SHOULD use SMART on FHIR or equivalent bearer-token authentication. Transport security (TLS) is REQUIRED. See the PH Core IG security section for base requirements."
+
+* rest[server].interaction[+].code = #transaction
+* rest[server].interaction[=].documentation = "Transaction Bundle support for atomic submission of referral packages. The Ana Reyes example uses POST for clinical resources and conditional PUT for master data within a single transaction Bundle."
+
+// =================================================================================
+// Resource: Patient
+// =================================================================================
+* rest[server].resource[+].type = #Patient
+* rest[server].resource[=].profile = "https://fhir.doh.gov.ph/pheref/StructureDefinition/ereferral-patient"
+* rest[server].resource[=].documentation = "Patient demographics and identifiers for referral subjects. Uses PhilSys ID for conditional update matching. Must Support: name, gender, birthDate, telecom, address (PSGC), contact/next of kin."
+* rest[server].resource[=].interaction[+].code = #read
+* rest[server].resource[=].interaction[+].code = #search-type
+* rest[server].resource[=].interaction[+].code = #create
+* rest[server].resource[=].interaction[+].code = #update
+* rest[server].resource[=].versioning = #no-version
+* rest[server].resource[=].readHistory = false
+* rest[server].resource[=].updateCreate = true
+* rest[server].resource[=].conditionalUpdate = true
+* rest[server].resource[=].conditionalDelete = #not-supported
+* rest[server].resource[=].searchParam[+].name = "identifier"
+* rest[server].resource[=].searchParam[=].type = #token
+* rest[server].resource[=].searchParam[=].definition = "http://hl7.org/fhir/SearchParameter/Patient-identifier"
+* rest[server].resource[=].searchParam[=].documentation = "Search by PhilSys ID or PhilHealth ID. Used for conditional update in transaction Bundles."
+* rest[server].resource[=].searchParam[+].name = "name"
+* rest[server].resource[=].searchParam[=].type = #string
+* rest[server].resource[=].searchParam[=].definition = "http://hl7.org/fhir/SearchParameter/Patient-name"
+* rest[server].resource[=].searchParam[=].documentation = "Search by patient name."
+* rest[server].resource[=].searchParam[+].name = "birthdate"
+* rest[server].resource[=].searchParam[=].type = #date
+* rest[server].resource[=].searchParam[=].definition = "http://hl7.org/fhir/SearchParameter/individual-birthdate"
+* rest[server].resource[=].searchParam[=].documentation = "Search by patient birth date."
+
+// =================================================================================
+// Resource: Practitioner
+// =================================================================================
+* rest[server].resource[+].type = #Practitioner
+* rest[server].resource[=].profile = "https://fhir.doh.gov.ph/phcore/StructureDefinition/ph-core-practitioner"
+* rest[server].resource[=].documentation = "Practitioner resource for referring and receiving clinicians. Uses PRC license number for conditional update matching."
+* rest[server].resource[=].interaction[+].code = #read
+* rest[server].resource[=].interaction[+].code = #search-type
+* rest[server].resource[=].interaction[+].code = #create
+* rest[server].resource[=].interaction[+].code = #update
+* rest[server].resource[=].versioning = #no-version
+* rest[server].resource[=].readHistory = false
+* rest[server].resource[=].updateCreate = true
+* rest[server].resource[=].conditionalUpdate = true
+* rest[server].resource[=].conditionalDelete = #not-supported
+* rest[server].resource[=].searchParam[+].name = "identifier"
+* rest[server].resource[=].searchParam[=].type = #token
+* rest[server].resource[=].searchParam[=].definition = "http://hl7.org/fhir/SearchParameter/Practitioner-identifier"
+* rest[server].resource[=].searchParam[=].documentation = "Search by PRC license number. Used for conditional update in transaction Bundles."
+* rest[server].resource[=].searchParam[+].name = "name"
+* rest[server].resource[=].searchParam[=].type = #string
+* rest[server].resource[=].searchParam[=].definition = "http://hl7.org/fhir/SearchParameter/Practitioner-name"
+* rest[server].resource[=].searchParam[=].documentation = "Search by practitioner name."
+
+// =================================================================================
+// Resource: Organization
+// =================================================================================
+* rest[server].resource[+].type = #Organization
+* rest[server].resource[=].profile = "https://fhir.doh.gov.ph/phcore/StructureDefinition/ph-core-organization"
+* rest[server].resource[=].documentation = "Organization resource for referring and receiving healthcare facilities. Uses NHFR facility code for conditional update. Includes HCPN network identifier and PSGC-coded address."
+* rest[server].resource[=].interaction[+].code = #read
+* rest[server].resource[=].interaction[+].code = #search-type
+* rest[server].resource[=].interaction[+].code = #create
+* rest[server].resource[=].interaction[+].code = #update
+* rest[server].resource[=].versioning = #no-version
+* rest[server].resource[=].readHistory = false
+* rest[server].resource[=].updateCreate = true
+* rest[server].resource[=].conditionalUpdate = true
+* rest[server].resource[=].conditionalDelete = #not-supported
+* rest[server].resource[=].searchParam[+].name = "identifier"
+* rest[server].resource[=].searchParam[=].type = #token
+* rest[server].resource[=].searchParam[=].definition = "http://hl7.org/fhir/SearchParameter/Organization-identifier"
+* rest[server].resource[=].searchParam[=].documentation = "Search by NHFR facility code. Used for conditional update in transaction Bundles."
+* rest[server].resource[=].searchParam[+].name = "name"
+* rest[server].resource[=].searchParam[=].type = #string
+* rest[server].resource[=].searchParam[=].definition = "http://hl7.org/fhir/SearchParameter/Organization-name"
+* rest[server].resource[=].searchParam[=].documentation = "Search by organization name."
+
+// =================================================================================
+// Resource: PractitionerRole
+// =================================================================================
+* rest[server].resource[+].type = #PractitionerRole
+* rest[server].resource[=].profile = "https://fhir.doh.gov.ph/pheref/StructureDefinition/ereferral-practitioner-role"
+* rest[server].resource[=].documentation = "PractitionerRole linking practitioners to facilities. Used for both sending context (referring practitioner) and receiving context (care navigator). Inherits PRC identifier from Practitioner for conditional update."
+* rest[server].resource[=].interaction[+].code = #read
+* rest[server].resource[=].interaction[+].code = #search-type
+* rest[server].resource[=].interaction[+].code = #create
+* rest[server].resource[=].interaction[+].code = #update
+* rest[server].resource[=].versioning = #no-version
+* rest[server].resource[=].readHistory = false
+* rest[server].resource[=].updateCreate = true
+* rest[server].resource[=].conditionalUpdate = true
+* rest[server].resource[=].conditionalDelete = #not-supported
+* rest[server].resource[=].searchParam[+].name = "identifier"
+* rest[server].resource[=].searchParam[=].type = #token
+* rest[server].resource[=].searchParam[=].definition = "http://hl7.org/fhir/SearchParameter/PractitionerRole-identifier"
+* rest[server].resource[=].searchParam[=].documentation = "Search by identifier (inherited PRC license). Used for conditional update."
+* rest[server].resource[=].searchParam[+].name = "practitioner"
+* rest[server].resource[=].searchParam[=].type = #reference
+* rest[server].resource[=].searchParam[=].definition = "http://hl7.org/fhir/SearchParameter/PractitionerRole-practitioner"
+* rest[server].resource[=].searchParam[+].name = "organization"
+* rest[server].resource[=].searchParam[=].type = #reference
+* rest[server].resource[=].searchParam[=].definition = "http://hl7.org/fhir/SearchParameter/PractitionerRole-organization"
+
+// =================================================================================
+// Resource: ServiceRequest
+// =================================================================================
+* rest[server].resource[+].type = #ServiceRequest
+* rest[server].resource[=].profile = "https://fhir.doh.gov.ph/pheref/StructureDefinition/ereferral-service-request"
+* rest[server].resource[=].documentation = "Primary referral request resource. Central artifact linking patient, requester (via PractitionerRole), performer (receiving facility), reasonCode, reasonReference, and supportingInfo."
+* rest[server].resource[=].interaction[+].code = #read
+* rest[server].resource[=].interaction[+].code = #search-type
+* rest[server].resource[=].interaction[+].code = #create
+* rest[server].resource[=].versioning = #no-version
+* rest[server].resource[=].readHistory = false
+* rest[server].resource[=].updateCreate = false
+* rest[server].resource[=].conditionalCreate = false
+* rest[server].resource[=].conditionalUpdate = false
+* rest[server].resource[=].conditionalDelete = #not-supported
+* rest[server].resource[=].searchParam[+].name = "performer"
+* rest[server].resource[=].searchParam[=].type = #reference
+* rest[server].resource[=].searchParam[=].definition = "http://hl7.org/fhir/SearchParameter/ServiceRequest-performer"
+* rest[server].resource[=].searchParam[=].documentation = "Search referrals by receiving facility. Used by receiving systems to find referrals directed to them."
+* rest[server].resource[=].searchParam[+].name = "status"
+* rest[server].resource[=].searchParam[=].type = #token
+* rest[server].resource[=].searchParam[=].definition = "http://hl7.org/fhir/SearchParameter/ServiceRequest-status"
+* rest[server].resource[=].searchParam[=].documentation = "Search referrals by status."
+* rest[server].resource[=].searchParam[+].name = "subject"
+* rest[server].resource[=].searchParam[=].type = #reference
+* rest[server].resource[=].searchParam[=].definition = "http://hl7.org/fhir/SearchParameter/ServiceRequest-subject"
+* rest[server].resource[=].searchParam[=].documentation = "Search referrals by patient."
+* rest[server].resource[=].searchParam[+].name = "authored"
+* rest[server].resource[=].searchParam[=].type = #date
+* rest[server].resource[=].searchParam[=].definition = "http://hl7.org/fhir/SearchParameter/ServiceRequest-authored"
+* rest[server].resource[=].searchParam[=].documentation = "Search by referral authored date."
+
+// =================================================================================
+// Resource: Task
+// =================================================================================
+* rest[server].resource[+].type = #Task
+* rest[server].resource[=].profile = "https://fhir.doh.gov.ph/pheref/StructureDefinition/ereferral-task"
+* rest[server].resource[=].documentation = "Workflow tracking resource for referral state management. Tracks progression: requested -> received -> accepted/rejected/referred-onward -> completed. Focus references the ServiceRequest."
+* rest[server].resource[=].interaction[+].code = #read
+* rest[server].resource[=].interaction[+].code = #search-type
+* rest[server].resource[=].interaction[+].code = #create
+* rest[server].resource[=].interaction[+].code = #update
+* rest[server].resource[=].versioning = #no-version
+* rest[server].resource[=].readHistory = false
+* rest[server].resource[=].updateCreate = false
+* rest[server].resource[=].conditionalCreate = false
+* rest[server].resource[=].conditionalUpdate = false
+* rest[server].resource[=].conditionalDelete = #not-supported
+* rest[server].resource[=].searchParam[+].name = "focus"
+* rest[server].resource[=].searchParam[=].type = #reference
+* rest[server].resource[=].searchParam[=].definition = "http://hl7.org/fhir/SearchParameter/Task-focus"
+* rest[server].resource[=].searchParam[=].documentation = "Search tasks by the ServiceRequest they track. Example: GET /Task?focus=ServiceRequest/{id}"
+* rest[server].resource[=].searchParam[+].name = "status"
+* rest[server].resource[=].searchParam[=].type = #token
+* rest[server].resource[=].searchParam[=].definition = "http://hl7.org/fhir/SearchParameter/Task-status"
+* rest[server].resource[=].searchParam[=].documentation = "Search tasks by workflow status."
+* rest[server].resource[=].searchParam[+].name = "owner"
+* rest[server].resource[=].searchParam[=].type = #reference
+* rest[server].resource[=].searchParam[=].definition = "http://hl7.org/fhir/SearchParameter/Task-owner"
+* rest[server].resource[=].searchParam[=].documentation = "Search tasks by assigned owner (receiving facility or care navigator)."
+* rest[server].resource[=].searchParam[+].name = "requester"
+* rest[server].resource[=].searchParam[=].type = #reference
+* rest[server].resource[=].searchParam[=].definition = "http://hl7.org/fhir/SearchParameter/Task-requester"
+* rest[server].resource[=].searchParam[=].documentation = "Search tasks by the requester."
+* rest[server].resource[=].searchParam[+].name = "patient"
+* rest[server].resource[=].searchParam[=].type = #reference
+* rest[server].resource[=].searchParam[=].definition = "http://hl7.org/fhir/SearchParameter/Task-patient"
+* rest[server].resource[=].searchParam[=].documentation = "Search tasks by patient."
+
+// =================================================================================
+// Resource: Encounter
+// =================================================================================
+* rest[server].resource[+].type = #Encounter
+* rest[server].resource[=].profile = "https://fhir.doh.gov.ph/pheref/StructureDefinition/ereferral-encounter"
+* rest[server].resource[=].documentation = "Encounter documenting clinical visit context for referral activities. Used for both initiating encounter and receiving (closure) encounter. basedOn references the ServiceRequest."
+* rest[server].resource[=].interaction[+].code = #read
+* rest[server].resource[=].interaction[+].code = #search-type
+* rest[server].resource[=].interaction[+].code = #create
+* rest[server].resource[=].versioning = #no-version
+* rest[server].resource[=].readHistory = false
+* rest[server].resource[=].updateCreate = false
+* rest[server].resource[=].conditionalCreate = false
+* rest[server].resource[=].conditionalUpdate = false
+* rest[server].resource[=].conditionalDelete = #not-supported
+* rest[server].resource[=].searchParam[+].name = "subject"
+* rest[server].resource[=].searchParam[=].type = #reference
+* rest[server].resource[=].searchParam[=].definition = "http://hl7.org/fhir/SearchParameter/Encounter-subject"
+* rest[server].resource[=].searchParam[+].name = "based-on"
+* rest[server].resource[=].searchParam[=].type = #reference
+* rest[server].resource[=].searchParam[=].definition = "http://hl7.org/fhir/SearchParameter/Encounter-based-on"
+
+// =================================================================================
+// Resource: Condition
+// =================================================================================
+* rest[server].resource[+].type = #Condition
+* rest[server].resource[=].profile = "https://fhir.doh.gov.ph/pheref/StructureDefinition/ereferral-condition"
+* rest[server].resource[=].documentation = "Condition resource for diagnoses and problems. Used for chief complaint (problem-list-item) and working impression (encounter-diagnosis). Linked to encounter."
+* rest[server].resource[=].interaction[+].code = #read
+* rest[server].resource[=].interaction[+].code = #search-type
+* rest[server].resource[=].interaction[+].code = #create
+* rest[server].resource[=].versioning = #no-version
+* rest[server].resource[=].readHistory = false
+* rest[server].resource[=].updateCreate = false
+* rest[server].resource[=].conditionalCreate = false
+* rest[server].resource[=].conditionalUpdate = false
+* rest[server].resource[=].conditionalDelete = #not-supported
+* rest[server].resource[=].searchParam[+].name = "subject"
+* rest[server].resource[=].searchParam[=].type = #reference
+* rest[server].resource[=].searchParam[=].definition = "http://hl7.org/fhir/SearchParameter/Condition-subject"
+* rest[server].resource[=].searchParam[+].name = "encounter"
+* rest[server].resource[=].searchParam[=].type = #reference
+* rest[server].resource[=].searchParam[=].definition = "http://hl7.org/fhir/SearchParameter/Condition-encounter"
+
+// =================================================================================
+// Resource: Observation
+// =================================================================================
+* rest[server].resource[+].type = #Observation
+* rest[server].resource[=].profile = "https://fhir.doh.gov.ph/pheref/StructureDefinition/ereferral-observation"
+* rest[server].resource[=].documentation = "Clinical observation resource for vital signs, lab results, and clinical measurements. Supports BP, heart rate, respiratory rate, SpO2, temperature, weight."
+* rest[server].resource[=].interaction[+].code = #read
+* rest[server].resource[=].interaction[+].code = #search-type
+* rest[server].resource[=].interaction[+].code = #create
+* rest[server].resource[=].versioning = #no-version
+* rest[server].resource[=].readHistory = false
+* rest[server].resource[=].updateCreate = false
+* rest[server].resource[=].conditionalCreate = false
+* rest[server].resource[=].conditionalUpdate = false
+* rest[server].resource[=].conditionalDelete = #not-supported
+* rest[server].resource[=].searchParam[+].name = "subject"
+* rest[server].resource[=].searchParam[=].type = #reference
+* rest[server].resource[=].searchParam[=].definition = "http://hl7.org/fhir/SearchParameter/Observation-subject"
+* rest[server].resource[=].searchParam[+].name = "encounter"
+* rest[server].resource[=].searchParam[=].type = #reference
+* rest[server].resource[=].searchParam[+].name = "code"
+* rest[server].resource[=].searchParam[=].type = #token
+
+// =================================================================================
+// Resource: Provenance
+// =================================================================================
+* rest[server].resource[+].type = #Provenance
+* rest[server].resource[=].profile = "https://fhir.doh.gov.ph/pheref/StructureDefinition/ereferral-provenance"
+* rest[server].resource[=].documentation = "Provenance resource for audit trail and signature attestation. Targets the ServiceRequest. Records author, timestamp, and professional signature."
+* rest[server].resource[=].interaction[+].code = #read
+* rest[server].resource[=].interaction[+].code = #search-type
+* rest[server].resource[=].interaction[+].code = #create
+* rest[server].resource[=].versioning = #no-version
+* rest[server].resource[=].readHistory = false
+* rest[server].resource[=].updateCreate = false
+* rest[server].resource[=].conditionalCreate = false
+* rest[server].resource[=].conditionalUpdate = false
+* rest[server].resource[=].conditionalDelete = #not-supported
+* rest[server].resource[=].searchParam[+].name = "target"
+* rest[server].resource[=].searchParam[=].type = #reference
+* rest[server].resource[=].searchParam[=].definition = "http://hl7.org/fhir/SearchParameter/Provenance-target"
+
+// =================================================================================
+// Resource: RelatedPerson
+// =================================================================================
+* rest[server].resource[+].type = #RelatedPerson
+* rest[server].resource[=].profile = "https://fhir.doh.gov.ph/pheref/StructureDefinition/ereferral-related-person"
+* rest[server].resource[=].documentation = "RelatedPerson for patient contacts, next of kin, guardians, and accompanying persons. Optional resource for separate contact details."
+* rest[server].resource[=].interaction[+].code = #read
+* rest[server].resource[=].interaction[+].code = #search-type
+* rest[server].resource[=].interaction[+].code = #create
+* rest[server].resource[=].versioning = #no-version
+* rest[server].resource[=].readHistory = false
+* rest[server].resource[=].updateCreate = false
+* rest[server].resource[=].conditionalCreate = false
+* rest[server].resource[=].conditionalUpdate = false
+* rest[server].resource[=].conditionalDelete = #not-supported
+* rest[server].resource[=].searchParam[+].name = "patient"
+* rest[server].resource[=].searchParam[=].type = #reference
+* rest[server].resource[=].searchParam[=].definition = "http://hl7.org/fhir/SearchParameter/RelatedPerson-patient"
+
+// =================================================================================
+// Resource: Procedure
+// =================================================================================
+* rest[server].resource[+].type = #Procedure
+* rest[server].resource[=].profile = "https://fhir.doh.gov.ph/pheref/StructureDefinition/ereferral-procedure"
+* rest[server].resource[=].documentation = "Procedure resource for treatments and procedures before or during the referral. Linked to encounter."
+* rest[server].resource[=].interaction[+].code = #read
+* rest[server].resource[=].interaction[+].code = #search-type
+* rest[server].resource[=].interaction[+].code = #create
+* rest[server].resource[=].versioning = #no-version
+* rest[server].resource[=].readHistory = false
+* rest[server].resource[=].updateCreate = false
+* rest[server].resource[=].conditionalCreate = false
+* rest[server].resource[=].conditionalUpdate = false
+* rest[server].resource[=].conditionalDelete = #not-supported
+* rest[server].resource[=].searchParam[+].name = "subject"
+* rest[server].resource[=].searchParam[=].type = #reference
+* rest[server].resource[=].searchParam[=].definition = "http://hl7.org/fhir/SearchParameter/Procedure-subject"
+* rest[server].resource[=].searchParam[+].name = "encounter"
+* rest[server].resource[=].searchParam[=].type = #reference
+
+// =================================================================================
+// Resource: MedicationAdministration
+// =================================================================================
+* rest[server].resource[+].type = #MedicationAdministration
+* rest[server].resource[=].profile = "https://fhir.doh.gov.ph/pheref/StructureDefinition/ereferral-medication-administration"
+* rest[server].resource[=].documentation = "MedicationAdministration for documenting medications administered. Linked to encounter for clinical context."
+* rest[server].resource[=].interaction[+].code = #read
+* rest[server].resource[=].interaction[+].code = #search-type
+* rest[server].resource[=].interaction[+].code = #create
+* rest[server].resource[=].versioning = #no-version
+* rest[server].resource[=].readHistory = false
+* rest[server].resource[=].updateCreate = false
+* rest[server].resource[=].conditionalCreate = false
+* rest[server].resource[=].conditionalUpdate = false
+* rest[server].resource[=].conditionalDelete = #not-supported
+* rest[server].resource[=].searchParam[+].name = "subject"
+* rest[server].resource[=].searchParam[=].type = #reference
+* rest[server].resource[=].searchParam[=].definition = "http://hl7.org/fhir/SearchParameter/MedicationAdministration-subject"
+* rest[server].resource[=].searchParam[+].name = "context"
+* rest[server].resource[=].searchParam[=].type = #reference
+* rest[server].resource[=].searchParam[=].definition = "http://hl7.org/fhir/SearchParameter/MedicationAdministration-context"
+
+// =================================================================================
+// Resource: Immunization
+// =================================================================================
+* rest[server].resource[+].type = #Immunization
+* rest[server].resource[=].profile = "https://fhir.doh.gov.ph/pheref/StructureDefinition/ereferral-immunization"
+* rest[server].resource[=].documentation = "Immunization resource for vaccination history as clinical context in referrals."
+* rest[server].resource[=].interaction[+].code = #read
+* rest[server].resource[=].interaction[+].code = #search-type
+* rest[server].resource[=].interaction[+].code = #create
+* rest[server].resource[=].versioning = #no-version
+* rest[server].resource[=].readHistory = false
+* rest[server].resource[=].updateCreate = false
+* rest[server].resource[=].conditionalCreate = false
+* rest[server].resource[=].conditionalUpdate = false
+* rest[server].resource[=].conditionalDelete = #not-supported
+* rest[server].resource[=].searchParam[+].name = "patient"
+* rest[server].resource[=].searchParam[=].type = #reference
+* rest[server].resource[=].searchParam[+].name = "vaccine-code"
+* rest[server].resource[=].searchParam[=].type = #token
+* rest[server].resource[=].searchParam[=].definition = "http://hl7.org/fhir/SearchParameter/Immunization-vaccine-code"
+
+// =================================================================================
+// Resource: DiagnosticReport
+// =================================================================================
+* rest[server].resource[+].type = #DiagnosticReport
+* rest[server].resource[=].profile = "http://hl7.org/fhir/StructureDefinition/DiagnosticReport"
+* rest[server].resource[=].documentation = "DiagnosticReport for laboratory results and diagnostic studies. Currently uses base FHIR profile."
+* rest[server].resource[=].interaction[+].code = #read
+* rest[server].resource[=].interaction[+].code = #search-type
+* rest[server].resource[=].interaction[+].code = #create
+* rest[server].resource[=].versioning = #no-version
+* rest[server].resource[=].readHistory = false
+* rest[server].resource[=].updateCreate = false
+* rest[server].resource[=].conditionalCreate = false
+* rest[server].resource[=].conditionalUpdate = false
+* rest[server].resource[=].conditionalDelete = #not-supported
+* rest[server].resource[=].searchParam[+].name = "subject"
+* rest[server].resource[=].searchParam[=].type = #reference
+* rest[server].resource[=].searchParam[=].definition = "http://hl7.org/fhir/SearchParameter/DiagnosticReport-subject"
+* rest[server].resource[=].searchParam[+].name = "encounter"
+* rest[server].resource[=].searchParam[=].type = #reference

--- a/input/fsh/profiles/ERefCapabilityStatement.fsh
+++ b/input/fsh/profiles/ERefCapabilityStatement.fsh
@@ -1,0 +1,30 @@
+Profile: ERefCapabilityStatement
+Parent: CapabilityStatement
+Id: ereferral-capability-statement
+Title: "PH eReferral CapabilityStatement"
+Description: "CapabilityStatement for the PH eReferral Implementation Guide. Defines the conformance requirements for FHIR servers implementing the eReferral workflow, including supported resource types, profiles, RESTful interactions, search parameters, and security expectations. Validated during the June 2026 Aklan Connectathon."
+
+* status 1..1
+* status = #draft
+* kind 1..1
+* kind = #requirements
+* fhirVersion = #4.0.1
+* format 1..*
+
+* rest 1..*
+* rest ^slicing.discriminator.type = #value
+* rest ^slicing.discriminator.path = "mode"
+* rest ^slicing.rules = #open
+* rest contains server 1..1
+* rest[server].mode = #server (exactly)
+* rest[server].security 1..1
+* rest[server].security insert ObligationRequired
+* rest[server].interaction 1..*
+* rest[server].resource 1..*
+* rest[server].resource.profile 1..1
+* rest[server].resource.interaction 1..*
+
+Invariant: ereferral-cs-1
+Description: "Server rest entry must declare transaction interaction"
+Severity: #error
+Expression: "rest.all(mode = 'server' implies interaction.where(code = 'transaction').exists())"

--- a/input/pagecontent/CapabilityStatement-ExampleERefCapabilityStatement-intro.md
+++ b/input/pagecontent/CapabilityStatement-ExampleERefCapabilityStatement-intro.md
@@ -1,0 +1,169 @@
+### PH eReferral Server CapabilityStatement
+
+The **PH eReferral CapabilityStatement** defines the conformance requirements for FHIR servers implementing the Philippine eReferral workflow, as validated at the **June 2026 Aklan Connectathon**.
+
+---
+
+#### Scope
+
+This CapabilityStatement describes the minimum server capabilities required to support the eReferral workflow lifecycle:
+
+| Step | Activity | Primary Artifacts |
+|------|----------|-------------------|
+| 1 | Create or update reference data (conditional PUT) | Patient, Practitioner, Organization, PractitionerRole |
+| 2 | Create referral request | ERefServiceRequest |
+| 3 | Create workflow tracking task | ERefTask (focus = ServiceRequest, status = requested) |
+| 4 | Search for referrals | Task, ServiceRequest |
+| 5 | Record receiving-facility response | ERefTask (update status, businessStatus) |
+| 6 | Record encounter, outcome, or onward referral | ERefEncounter, ServiceRequest, Task |
+| 7 | Submit as a transaction Bundle | Bundle (type = transaction) |
+{:.ph-table}
+
+---
+
+#### Conformance Expectations
+
+This CapabilityStatement uses the `capabilitystatement-expectation` extension (following the **AU Core** and **AU eRequesting** IG convention) to indicate the level of conformance required for each resource, interaction, and search parameter:
+
+| Code | Meaning |
+|------|---------|
+| **SHALL** | Required. The server MUST support this feature. Missing support is a conformance failure. |
+| **SHOULD** | Recommended. The server ought to support this feature unless there is a documented justification. |
+| **MAY** | Optional. The server may support this feature. Interoperability may be affected if not supported. |
+{:.ph-table}
+
+---
+
+#### Supported Resources
+
+| Resource Type | Profile | Expectation |
+|---------------|---------|-------------|
+| Patient | [ERefPatient](StructureDefinition-ereferral-patient.html) | **SHALL** |
+| Practitioner | [PHCorePractitioner](https://fhir.doh.gov.ph/phcore/StructureDefinition/ph-core-practitioner) | **SHALL** |
+| Organization | [PHCoreOrganization](https://fhir.doh.gov.ph/phcore/StructureDefinition/ph-core-organization) | **SHALL** |
+| PractitionerRole | [EReferral PractitionerRole](StructureDefinition-ereferral-practitioner-role.html) | **SHALL** |
+| ServiceRequest | [EReferral ServiceRequest](StructureDefinition-ereferral-service-request.html) | **SHALL** |
+| Task | [EReferral Task](StructureDefinition-ereferral-task.html) | **SHALL** |
+| Encounter | [ERefEncounter](StructureDefinition-ereferral-encounter.html) | **SHALL** |
+| Condition | [ERefCondition](StructureDefinition-ereferral-condition.html) | **SHOULD** |
+| Observation | [ERefObservation](StructureDefinition-ereferral-observation.html) | **SHOULD** |
+| Provenance | [EReferral Provenance](StructureDefinition-ereferral-provenance.html) | **SHOULD** |
+| RelatedPerson | [EReferral RelatedPerson](StructureDefinition-ereferral-related-person.html) | **MAY** |
+| Procedure | [ERefProcedure](StructureDefinition-ereferral-procedure.html) | **MAY** |
+| MedicationAdministration | [EReferral MedicationAdministration](StructureDefinition-ereferral-medication-administration.html) | **MAY** |
+| Immunization | [ERefImmunization](StructureDefinition-ereferral-immunization.html) | **MAY** |
+| DiagnosticReport | (base FHIR) | **MAY** |
+{:.ph-table}
+
+---
+
+#### RESTful Interactions
+
+| Resource | read | search-type | create | update |
+|----------|------|-------------|--------|--------|
+| Patient | SHALL | SHALL | SHOULD | SHOULD |
+| Practitioner | SHALL | SHALL | SHOULD | SHOULD |
+| Organization | SHALL | SHALL | SHOULD | SHOULD |
+| PractitionerRole | SHALL | SHALL | SHOULD | SHOULD |
+| ServiceRequest | SHALL | SHALL | SHOULD | — |
+| Task | SHALL | SHALL | SHOULD | SHOULD |
+| Encounter | SHALL | SHALL | SHOULD | — |
+| Condition | SHALL | SHALL | SHOULD | — |
+| Observation | SHALL | SHALL | SHOULD | — |
+| Provenance | SHALL | SHALL | SHOULD | — |
+| RelatedPerson | SHALL | SHALL | MAY | — |
+| Procedure | SHALL | SHALL | MAY | — |
+| MedicationAdministration | SHALL | SHALL | MAY | — |
+| Immunization | SHALL | SHALL | MAY | — |
+| DiagnosticReport | SHALL | SHALL | MAY | — |
+{:.ph-table}
+
+**System-level interactions:**
+
+| Interaction | Expectation | Description |
+|-------------|-------------|-------------|
+| transaction | **SHALL** | Atomic submission of referral packages (see [Submission Bundle](Bundle-ExampleERefSubmissionBundle.html)) |
+| batch | MAY | Non-atomic batch processing |
+{:.ph-table}
+
+---
+
+#### Search Parameters
+
+The following search parameters are supported per resource type. Identifier-based searches enable conditional update in transaction Bundles.
+
+**Master data resources** use identifier searches for idempotent upsert (conditional PUT):
+
+| Resource | Search Params |
+|----------|--------------|
+| Patient | `_id`, `identifier` (PhilSys/PhilHealth), `name`, `birthdate` |
+| Practitioner | `_id`, `identifier` (PRC license), `name` |
+| Organization | `_id`, `identifier` (NHFR facility code), `name` |
+| PractitionerRole | `_id`, `identifier` (inherited PRC), `practitioner`, `organization` |
+{:.ph-table}
+
+**Clinical and workflow resources** enable referrer and receiver to find and update referrals:
+
+| Resource | Search Params |
+|----------|--------------|
+| ServiceRequest | `_id`, `performer`, `status`, `subject`, `authored` |
+| Task | `_id`, `focus`, `status`, `owner`, `requester`, `patient` |
+| Encounter | `_id`, `subject`, `based-on` |
+| Condition | `_id`, `subject`, `encounter` |
+| Observation | `_id`, `subject`, `encounter`, `code` |
+| Provenance | `_id`, `target` |
+| RelatedPerson | `_id`, `patient` |
+| Procedure | `_id`, `subject`, `encounter` |
+| MedicationAdministration | `_id`, `subject`, `context` |
+| Immunization | `_id`, `patient`, `vaccine-code` |
+| DiagnosticReport | `_id`, `subject`, `encounter` |
+{:.ph-table}
+
+**Supported `_include` and `_revinclude` parameters:**
+
+| Source Resource | `_include` | `_revinclude` |
+|----------------|------------|---------------|
+| ServiceRequest | `ServiceRequest:patient`, `ServiceRequest:requester`, `ServiceRequest:performer`, `ServiceRequest:encounter`, `ServiceRequest:supporting-info` | `Task:focus` |
+| Task | `Task:focus`, `Task:owner`, `Task:patient`, `Task:requester` | — |
+| Encounter | `Encounter:subject`, `Encounter:based-on` | `ServiceRequest:encounter` |
+| Condition | `Condition:subject`, `Condition:encounter` | — |
+| Observation | `Observation:subject`, `Observation:encounter` | — |
+{:.ph-table}
+
+---
+
+#### Security
+
+Implementations **SHOULD** use [SMART on FHIR](http://www.hl7.org/fhir/smart-app-launch/) or equivalent bearer-token authentication. Transport security (TLS) is **REQUIRED** for all production deployments.
+
+See the PH Core IG for base security requirements and the [sample-case-ana-reyes](sample-case-ana-reyes.html) page for the Connectathon test server configuration (`https://cdr.fhirlab.net/fhir`).
+
+---
+
+#### Transaction Bundle Pattern
+
+The eReferral workflow uses a **transaction Bundle** (`Bundle.type = #transaction`) for atomic submission of the complete referral package:
+
+| Entry Type | HTTP Method | Resources | Purpose |
+|------------|-------------|-----------|---------|
+| Master data | **PUT** (conditional by identifier) | Patient, Practitioner, Organization, PractitionerRole | Idempotent upsert — updates existing or creates new |
+| Clinical data | **POST** | ServiceRequest, Task, Encounter, Condition, Observation, Procedure, Provenance, DiagnosticReport | Always creates new resources per referral instance |
+{:.ph-table}
+
+Each entry uses `urn:uuid:` identifiers for `fullUrl`, enabling consistent intra-Bundle references. The [Example Submission Bundle](Bundle-ExampleERefSubmissionBundle.html) demonstrates this pattern for the Ana Reyes referral scenario.
+
+---
+
+#### Related Profiles
+
+This CapabilityStatement builds on profiles defined in the **PH Core IG** ([fhir.ph.core](https://fhir.doh.gov.ph/phcore)). All eReferral profiles extend their PH Core equivalents to ensure base-level interoperability across Philippine health information exchange.
+
+---
+
+#### See Also
+
+- [Example Submission Bundle](Bundle-ExampleERefSubmissionBundle.html) — Complete transaction bundle
+- [Sample Case: Ana Reyes](sample-case-ana-reyes.html) — End-to-end workflow tutorial
+- [Referral Workflow](referral-workflow.html) — Workflow narrative
+- [Logical Information Model](logical-information-model.html) — Data model mapping
+- [Connectathon Readiness](connectathon-readiness.html) — Test pack and instructions

--- a/input/pagecontent/logical-information-model.md
+++ b/input/pagecontent/logical-information-model.md
@@ -136,7 +136,7 @@ specialty or program-specific referral use cases.
 The following flow is illustrative and non-normative. Do not treat it as a
 required API contract. Actual supported searches, update methods, transaction
 behavior, and security controls should be stated in the server
-CapabilityStatement and exchange agreement.
+[CapabilityStatement](CapabilityStatement-ExampleERefCapabilityStatement.html) and exchange agreement.
 
 Each interaction implies a corresponding FHIR REST response, such as `200 OK`,
 `201 Created`, or an `OperationOutcome`. Standard HTTP responses are omitted
@@ -203,7 +203,7 @@ from the diagram for readability.
 | Create or update shared reference data | `POST /Patient`, `PUT /Patient/{id}`, `POST /Organization`, `POST /PractitionerRole` | ERefPatient, Organization, Practitioner, PractitionerRole | Use existing records when available. Create or update only when the exchange agreement allows it. |
 | Create the referral request | `POST /ServiceRequest` | ERefServiceRequest | Carries patient, requester, receiving performer, requested service, urgency, reason, and supporting clinical references. |
 | Create workflow tracking | `POST /Task` | ERefTask | `Task.focus` points to the ServiceRequest. Initial v0.1 exchange normally starts with a requested Task. |
-| Read or search for referrals | `GET /Task?focus=ServiceRequest/{id}`, `GET /ServiceRequest?performer=Organization/{id}&status=active` | Task, ServiceRequest | These are example searches. Actual support belongs in the server CapabilityStatement. |
+| Read or search for referrals | `GET /Task?focus=ServiceRequest/{id}`, `GET /ServiceRequest?performer=Organization/{id}&status=active` | Task, ServiceRequest | These are example searches. Actual support belongs in the server [CapabilityStatement](CapabilityStatement-ExampleERefCapabilityStatement.html). |
 | Record receiving response | `PUT /Task/{id}` or `PATCH /Task/{id}` | ERefTask | Updates `Task.status`, `Task.businessStatus`, `Task.statusReason`, and/or `Task.output` depending on the response. |
 | Record onward referral | `POST /ServiceRequest`; `PUT/PATCH /Task/{id}` | ServiceRequest, Task | An onward ServiceRequest can use `ServiceRequest.replaces` to link back to the previous referral request. |
 | Record audit event or signature | `POST /Provenance` | ERefProvenance | Provenance can target the ServiceRequest and record signer, author, update, or other auditable activity. |
@@ -220,7 +220,7 @@ Reviewers should confirm:
 - the logical groups match clinical and operational expectations for v0.1;
 - the data dictionary row clusters are accurate;
 - the profile relationships are consistent with the current PeReF profiles;
-- REST interaction examples match the intended server CapabilityStatement;
+- REST interaction examples match the intended server [CapabilityStatement](CapabilityStatement-ExampleERefCapabilityStatement.html);
 - future use cases can extend clinical content without replacing the core
   referral envelope;
 - production topics such as routing, consent, security, attachments, and


### PR DESCRIPTION
## Summary

Adds an **ERefCapabilityStatement** profile (StructureDefinition on `CapabilityStatement`) and a concrete **ExampleERefCapabilityStatement** instance documenting the conformance requirements validated during the **June 2026 Aklan Connectathon**.

### Scoping Review: AU Core & AU eRequesting Comparison

Before implementing, a comparative scoping review was conducted against:
- **[AU Core Server CapabilityStatement](https://build.fhir.org/ig/hl7au/au-fhir-core/CapabilityStatement-au-core-server.html)** — HL7 Australia's base FHIR IG
- **[AU eRequesting Server CapabilityStatement](https://build.fhir.org/ig/hl7au/au-fhir-ereq/CapabilityStatement-au-ereq-server.html)** — HL7 Australia's eReferral/eRequesting IG

#### Key findings adopted in this implementation:

| Finding | AU Core | AU eReq | PH eReferral (this PR) |
|---|---|---|---|
| **Expectation extensions** | ✅ SHALL/SHOULD/MAY on every resource + interaction | ✅ Same pattern | **✅ Added** `capabilitystatement-expectation` extension on all resources and interactions |
| **`_id` search param** | ✅ On every resource | ✅ On every resource | **✅ Added** `_id` to all 15 resource entries |
| **`searchInclude`/`searchRevInclude`** | ✅ Comprehensive | ✅ Comprehensive | **✅ Added** `searchInclude` + `searchRevInclude` for workflow-appropriate resources (ServiceRequest, Task, Encounter, Condition, Observation) |
| **`implementationGuide`** | ✅ Declares dependent IGs | ✅ `au-fhir-core`, `au-fhir-ereq` | **✅ Added** PH Core dependency |
| **`supportedProfile`** | ✅ Uses array for multiple profiles | ✅ Uses array (eReq + Core + IPS) | ❌ Not yet — profile constraint uses singular `profile`; deferred for future iteration |
| **Resource `versioning`/`updateCreate`** | ❌ Not declared | ❌ Not declared | **✅ Removed** — too implementation-specific |
| **Narrative intro page** | ✅ Rich tables | ✅ Rich tables | **✅ Added** styled `.ph-table` intro page |
| **Security** | Simple description | None defined | SMART-on-FHIR + TLS (kept from original) |

#### Key differences (not adopted, documented for awareness):

- **Chained search params** — AU eReq uses chained `owner.identifier`, `patient.identifier` on Task. PH eReferral defers this as it requires PH Core search parameter coordination.
- **Search parameter combinations** — AU eReq uses `capabilitystatement-search-parameter-combination` for Task (`owner+status`, `patient+status`). Useful but complex for v0.1.
- **Actor-specific CapabilityStatements** — AU eReq splits into Placer, Filler, Patient Access, Server CS. PH eReferral has a single server CS for v0.1.
- **`patchFormat`** — AU Core declares `application/json-patch+json` as SHOULD. Not needed for current workflow.
- **Consent, Coverage, Device, DocumentReference** — AU eReq supports these; PH eReferral doesn't include them yet.

### Artifacts

| Artifact | Type | File |
|---|---|---|
| `ERefCapabilityStatement` | Profile (StructureDefinition) on CapabilityStatement | `input/fsh/profiles/ERefCapabilityStatement.fsh` |
| `ExampleERefCapabilityStatement` | Instance | `input/fsh/examples/ERefCapabilityStatementExample.fsh` |
| Narrative intro | Markdown page | `input/pagecontent/CapabilityStatement-ExampleERefCapabilityStatement-intro.md` |

### Key Profile Constraints

- `kind = #requirements`
- `fhirVersion = 4.0.1`
- `format` includes `json` and `xml`
- `rest.mode = #server`
- `rest.security` Must Support with obligation
- `rest.interaction` transaction required (invariant `ereferral-cs-1`)
- `implementationGuide` declares PH Core dependency
- `rest.resource` entries must declare profile and at least read + search-type interactions

### Resource Entries with Conformance Expectations (16 total)

| Expectation | Resource Types | Count |
|---|---|---|
| **SHALL** | Patient, Practitioner, Organization, PractitionerRole, ServiceRequest, Task, Encounter | 7 |
| **SHOULD** | Condition, Observation, Provenance | 3 |
| **MAY** | RelatedPerson, Procedure, MedicationAdministration, Immunization, DiagnosticReport | 5 |

### Conformance Expectation Levels

Following the AU Core/AU eReq pattern, every resource and interaction is annotated with the `capabilitystatement-expectation` extension:

- **SHALL**: Required for conformance (read + search-type for all; create + update for master data)
- **SHOULD**: Recommended (create for clinical resources; update for Task)
- **MAY**: Optional (create for optional supporting resources)

### Search Parameters Declared

Every resource includes `_id` search (standard). Additional workflow-specific params:

- **Master data (conditional PUT)**: `identifier` (PhilSys, PRC, NHFR codes)
- **Referral lookup**: `performer`, `status`, `subject`, `authored` (ServiceRequest)
- **Workflow tracking**: `focus`, `status`, `owner`, `requester`, `patient` (Task)
- **Clinical context**: `subject`, `encounter`, `code`, `based-on`, `target`, `patient`, `context`, `vaccine-code`

### Supported `_include` / `_revinclude`

- ServiceRequest: `_include` patient, requester, performer, encounter, supporting-info; `_revinclude` Task:focus
- Task: `_include` focus, owner, patient, requester
- Encounter: `_include` subject, based-on; `_revinclude` ServiceRequest:encounter
- Condition / Observation: `_include` subject, encounter

### Other Changes

- `input/fsh/aliases.fsh`: Added `$cs-expectation` and `$restful-security-service`
- `input/pagecontent/logical-information-model.md`: Updated 3 cross-references to point to the new CapabilityStatement page

### Build Verification

- SUSHI: 0 errors, 0 warnings
- IG Publisher: 0 errors, 0 broken links, 120 warnings (all pre-existing)

### AI-Generated Content Disclaimer

> **⚠️ AI-Generated -- Requires Human Review**
>
> This pull request was generated with significant AI assistance. While it has been validated against the IG Publisher (0 errors), the following should be reviewed by a human domain expert:
>
> 1. **Conformance expectations** — The SHALL/SHOULD/MAY levels assigned to each resource and interaction need clinical and technical domain review.
> 2. **Security section** — "SMART on FHIR or equivalent bearer-token authentication" needs security workstream confirmation.
> 3. **Search parameter completeness** — Review if any Connectathon-validated searches are missing.
> 4. **Resource interaction accuracy** — Create + update expectations for master data vs clinical resources.
> 5. **DiagnosticReport profile** — Currently uses base FHIR profile; issue #110 tracks this.
> 6. **Profile naming** — Renamed from "PeRefCapabilityStatement" (per issue) to "ERefCapabilityStatement" for naming consistency.

### Guidance for PH Core Adoption

PH Core issue [#359](https://github.com/UP-Manila-SILab/ph-core/issues/359) tracks a similar CapabilityStatement. Key adoption notes:

| Aspect | PH eReferral | PH Core |
|---|---|---|
| **Scope** | eReferral-specific workflow | All PH Core profiles (broader) |
| **Expectation levels** | SHALL/SHOULD/MAY per resource | May use same or different |
| **Search params** | Referral-focused (identifier conditional updates) | All PH Core search params (more per resource) |
| **`_include`** | Workflow-specific | Should align with PH Core relationships |
| **Custom SearchParameters** | None defined | May define custom search params with `SearchParameter` resources |
| **Transaction** | REQUIRED (invariant enforced) | May be optional |
| **Security** | SMART-on-FHIR + TLS | Align with PH Core security baseline |

Keywords: `CapabilityStatement`, `Conformance`, `Server`, `REST API`, `FHIR 4.0.1`, `kind=requirements`, `SearchParameter`, `interaction`, `resource`, `profile`, `transaction`, `conditional update`, `SMART-on-FHIR`, `Connectathon Aklan 2026`
